### PR TITLE
Localize marketing pages and document translation keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@ Next.js 14 기반으로 재구성한 콜라보리움 아티스트 팬 협업 플
 - Prisma 스키마, NextAuth 인증, Stripe 결제/정산 API 스텁, i18next 다국어 지원
 - Zustand 기반 전역 상태, React Query 데이터 패칭, Jest + RTL 컴포넌트 테스트
 
+## 번역 키 구조
+- `common.loading`: 공용 로딩 메시지
+- `navigation.*`: 헤더/푸터 네비게이션 레이블
+- `actions.*`: 버튼 및 접근성 레이블 (예: `actions.viewMore`)
+- `home.*`: 홈 탭 전용 텍스트. `home.store.items`와 `home.liveAma`에 세부 문구를 묶어 관리합니다.
+- `projects.*`: 프로젝트 목록 및 필터 섹션 문자열 (`projects.overviewTitle`, `projects.overviewDescription` 등)
+- `community.*`, `partners.*`: 커뮤니티/파트너 관련 복합 UI 텍스트
+- `help.*`: FAQ 페이지 제목, 설명 및 `help.faqs.{id}` 구조의 질문-답변 페어
+
 ## 개발 환경
 ```bash
 npm install

--- a/app/help/page.tsx
+++ b/app/help/page.tsx
@@ -1,25 +1,20 @@
-const faqs = [
-  {
-    question: '펀딩은 어떻게 진행되나요?',
-    answer:
-      '프로젝트 오픈 → 팬 서포트 → 목표 달성 시 정산 및 리워드 제공 순으로 진행됩니다. Stripe 테스트 결제를 활용해 미리 시뮬레이션할 수 있습니다.'
-  },
-  {
-    question: '파트너 검수는 얼마나 걸리나요?',
-    answer: '제출 후 영업일 기준 3~5일 소요되며, 결과는 이메일로 안내드립니다.'
-  },
-  {
-    question: '정산 리포트는 어디에서 확인하나요?',
-    answer: '프로젝트 상세 페이지의 Settlement 탭에서 확인할 수 있습니다.'
-  }
-];
+'use client';
+
+import { useTranslation } from 'react-i18next';
 
 export default function HelpPage() {
+  const { t } = useTranslation();
+  const faqKeys = ['fundingProcess', 'partnerReview', 'settlementReport'] as const;
+  const faqs = faqKeys.map((key) => ({
+    question: t(`help.faqs.${key}.question`),
+    answer: t(`help.faqs.${key}.answer`)
+  }));
+
   return (
     <div className="mx-auto max-w-4xl px-4 pb-20">
       <header className="pt-6">
-        <h1 className="text-3xl font-semibold text-white">도움말 & FAQ</h1>
-        <p className="mt-2 text-sm text-white/60">서비스 이용 중 자주 묻는 질문을 정리했습니다.</p>
+        <h1 className="text-3xl font-semibold text-white">{t('help.title')}</h1>
+        <p className="mt-2 text-sm text-white/60">{t('help.description')}</p>
       </header>
       <section className="mt-10 space-y-4">
         {faqs.map((faq) => (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,7 @@
+'use client';
+
 import Link from 'next/link';
+import { useTranslation } from 'react-i18next';
 
 import { HeroCarousel } from '@/components/sections/hero-carousel';
 import { CategoryFilter } from '@/components/sections/category-filter';
@@ -7,30 +10,31 @@ import { SectionHeader } from '@/components/shared/section-header';
 import { StoreCard } from '@/components/shared/store-card';
 import { demoProjects } from '@/lib/data/projects';
 
-const storeItems = [
-  {
-    id: 'product-1',
-    title: '한정판 투어 후드 티',
-    price: 89000,
-    discount: 15,
-    image: 'https://images.unsplash.com/photo-1521572163474-6864f9cf17ab'
-  },
-  {
-    id: 'product-2',
-    title: '프리미엄 온라인 클래스 패스',
-    price: 129000,
-    image: 'https://images.unsplash.com/photo-1521737604893-d14cc237f11d'
-  },
-  {
-    id: 'product-3',
-    title: '아티스트 사인 LP',
-    price: 159000,
-    discount: 10,
-    image: 'https://images.unsplash.com/photo-1485579149621-3123dd979885'
-  }
-];
-
 export default function HomePage() {
+  const { t } = useTranslation();
+  const storeItems = [
+    {
+      id: 'product-1',
+      title: t('home.store.items.product1.title'),
+      price: 89000,
+      discount: 15,
+      image: 'https://images.unsplash.com/photo-1521572163474-6864f9cf17ab'
+    },
+    {
+      id: 'product-2',
+      title: t('home.store.items.product2.title'),
+      price: 129000,
+      image: 'https://images.unsplash.com/photo-1521737604893-d14cc237f11d'
+    },
+    {
+      id: 'product-3',
+      title: t('home.store.items.product3.title'),
+      price: 159000,
+      discount: 10,
+      image: 'https://images.unsplash.com/photo-1485579149621-3123dd979885'
+    }
+  ];
+
   return (
     <div className="mx-auto flex max-w-7xl flex-col gap-16 px-4 pb-20">
       <section className="pt-4 lg:pt-0">
@@ -39,7 +43,11 @@ export default function HomePage() {
 
       <section className="grid gap-6 lg:grid-cols-[2fr_1fr]">
         <div className="space-y-6">
-          <SectionHeader title="실시간 인기" href="/projects" />
+          <SectionHeader
+            title={t('home.livePopular')}
+            href="/projects"
+            ctaLabel={t('actions.viewMore') ?? undefined}
+          />
           <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
             {demoProjects.map((project) => (
               <ProjectCard key={project.id} project={project} />
@@ -47,13 +55,13 @@ export default function HomePage() {
           </div>
         </div>
         <div className="space-y-4 rounded-3xl border border-white/10 bg-white/5 p-6">
-          <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-white/60">Live AMA</h3>
-          <p className="text-2xl font-semibold text-white">이번 주 라이브 클래스</p>
-          <p className="text-sm text-white/60">
-            아티스트와 직접 소통하는 원더월 스타일 AMA 세션. 지금 예약하면 얼리버드 혜택을 드립니다.
-          </p>
+          <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-white/60">
+            {t('home.liveAma.tag')}
+          </h3>
+          <p className="text-2xl font-semibold text-white">{t('home.liveAma.title')}</p>
+          <p className="text-sm text-white/60">{t('home.liveAma.description')}</p>
           <Link href="/projects/1" className="inline-flex w-fit rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground">
-            참가 신청
+            {t('home.liveAma.cta')}
           </Link>
         </div>
       </section>
@@ -61,7 +69,11 @@ export default function HomePage() {
       <CategoryFilter />
 
       <section>
-        <SectionHeader title="마감 임박" href="/projects?sort=closing" />
+        <SectionHeader
+          title={t('home.closingSoon')}
+          href="/projects?sort=closing"
+          ctaLabel={t('actions.viewMore') ?? undefined}
+        />
         <div className="flex gap-6 overflow-x-auto pb-4">
           {demoProjects.map((project) => (
             <div key={project.id} className="min-w-[280px] max-w-xs flex-1">
@@ -72,7 +84,11 @@ export default function HomePage() {
       </section>
 
       <section>
-        <SectionHeader title="테마별 추천" href="/projects?theme=1" />
+        <SectionHeader
+          title={t('home.themes')}
+          href="/projects?theme=1"
+          ctaLabel={t('actions.viewMore') ?? undefined}
+        />
         <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
           {demoProjects.map((project) => (
             <ProjectCard key={`theme-${project.id}`} project={project} />
@@ -81,7 +97,11 @@ export default function HomePage() {
       </section>
 
       <section>
-        <SectionHeader title="스토어" href="/projects?tab=store" />
+        <SectionHeader
+          title={t('home.store.title')}
+          href="/projects?tab=store"
+          ctaLabel={t('actions.viewMore') ?? undefined}
+        />
         <div className="grid gap-6 md:grid-cols-3">
           {storeItems.map((item) => (
             <StoreCard key={item.id} product={item} />

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,4 +1,7 @@
+'use client';
+
 import { Suspense } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { CategoryFilter } from '@/components/sections/category-filter';
 import { ProjectFilterPanel } from '@/components/sections/project-filter-panel';
@@ -6,16 +9,15 @@ import { SectionHeader } from '@/components/shared/section-header';
 import { demoProjects } from '@/lib/data/projects';
 
 export default function ProjectsPage() {
+  const { t } = useTranslation();
   return (
     <div className="mx-auto flex max-w-7xl flex-col gap-12 px-4 pb-20">
       <header className="pt-4">
-        <SectionHeader title="프로젝트 전체" />
-        <p className="max-w-2xl text-sm text-white/60">
-          카테고리, 정렬, 태그 필터를 활용해 팬과 아티스트가 함께 만드는 다양한 프로젝트를 탐색해 보세요.
-        </p>
+        <SectionHeader title={t('projects.overviewTitle')} />
+        <p className="max-w-2xl text-sm text-white/60">{t('projects.overviewDescription')}</p>
       </header>
       <CategoryFilter />
-      <Suspense fallback={<div>Loading...</div>}>
+      <Suspense fallback={<div>{t('common.loading')}</div>}>
         <ProjectFilterPanel initialProjects={demoProjects} />
       </Suspense>
     </div>

--- a/components/shared/section-header.tsx
+++ b/components/shared/section-header.tsx
@@ -4,9 +4,10 @@ import { ArrowUpRight } from 'lucide-react';
 interface SectionHeaderProps {
   title: string;
   href?: string;
+  ctaLabel?: string;
 }
 
-export function SectionHeader({ title, href }: SectionHeaderProps) {
+export function SectionHeader({ title, href, ctaLabel }: SectionHeaderProps) {
   return (
     <div className="mb-6 flex items-center justify-between">
       <h2 className="text-xl font-semibold text-white">{title}</h2>
@@ -15,7 +16,7 @@ export function SectionHeader({ title, href }: SectionHeaderProps) {
           href={href}
           className="inline-flex items-center gap-1 text-sm text-white/60 transition hover:text-white"
         >
-          더 보기
+          {ctaLabel ?? '더 보기'}
           <ArrowUpRight className="h-4 w-4" />
         </Link>
       ) : null}

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -1,4 +1,7 @@
 {
+  "common": {
+    "loading": "Loading..."
+  },
   "navigation": {
     "home": "Home",
     "explore": "Explore",
@@ -16,6 +19,7 @@
     "logout": "Log out",
     "search": "Search",
     "favorite": "Favorite",
+    "viewMore": "View more",
     "viewAll": "View all",
     "fundNow": "Fund now",
     "requestQuote": "Request quote"
@@ -27,10 +31,26 @@
     "closingSoon": "Closing soon",
     "themes": "Themes",
     "categoryFilter": "Category filters",
-    "tagFilter": "Tags"
+    "tagFilter": "Tags",
+    "store": {
+      "title": "Store",
+      "items": {
+        "product1": { "title": "Limited tour hoodie" },
+        "product2": { "title": "Premium online class pass" },
+        "product3": { "title": "Artist-signed LP" }
+      }
+    },
+    "liveAma": {
+      "tag": "Live AMA",
+      "title": "This week's live class",
+      "description": "Join an intimate AMA session with the artist. Reserve now to secure the early-bird perks.",
+      "cta": "Reserve a spot"
+    }
   },
   "projects": {
     "title": "Projects",
+    "overviewTitle": "All projects",
+    "overviewDescription": "Use category, sort and tag filters to explore collaborative experiences built by artists and fans.",
     "filters": "Filters",
     "category": "Category",
     "status": "Status",
@@ -49,5 +69,23 @@
     "title": "Partner matching",
     "submit": "Submit partner",
     "review": "Review status"
+  },
+  "help": {
+    "title": "Help & FAQ",
+    "description": "Answers to the most common questions when using the service.",
+    "faqs": {
+      "fundingProcess": {
+        "question": "How does funding work?",
+        "answer": "Projects open → fans support → once the goal is reached we settle the payment and deliver rewards. You can rehearse the flow with Stripe test payments."
+      },
+      "partnerReview": {
+        "question": "How long does partner review take?",
+        "answer": "It takes 3–5 business days after submission and we will notify you via email."
+      },
+      "settlementReport": {
+        "question": "Where can I find settlement reports?",
+        "answer": "Go to the Settlement tab on the project detail page to access the reports."
+      }
+    }
   }
 }

--- a/locales/ko/common.json
+++ b/locales/ko/common.json
@@ -1,4 +1,7 @@
 {
+  "common": {
+    "loading": "로딩 중..."
+  },
   "navigation": {
     "home": "홈",
     "explore": "탐색",
@@ -16,6 +19,7 @@
     "logout": "로그아웃",
     "search": "검색",
     "favorite": "즐겨찾기",
+    "viewMore": "더 보기",
     "viewAll": "전체 보기",
     "fundNow": "지금 후원하기",
     "requestQuote": "견적 요청"
@@ -27,10 +31,26 @@
     "closingSoon": "마감 임박",
     "themes": "테마별 추천",
     "categoryFilter": "카테고리 필터",
-    "tagFilter": "태그"
+    "tagFilter": "태그",
+    "store": {
+      "title": "스토어",
+      "items": {
+        "product1": { "title": "한정판 투어 후드 티" },
+        "product2": { "title": "프리미엄 온라인 클래스 패스" },
+        "product3": { "title": "아티스트 사인 LP" }
+      }
+    },
+    "liveAma": {
+      "tag": "Live AMA",
+      "title": "이번 주 라이브 클래스",
+      "description": "아티스트와 직접 소통하는 원더월 스타일 AMA 세션. 지금 예약하면 얼리버드 혜택을 드립니다.",
+      "cta": "참가 신청"
+    }
   },
   "projects": {
     "title": "프로젝트",
+    "overviewTitle": "프로젝트 전체",
+    "overviewDescription": "카테고리, 정렬, 태그 필터를 활용해 팬과 아티스트가 함께 만드는 다양한 프로젝트를 탐색해 보세요.",
     "filters": "필터",
     "category": "카테고리",
     "status": "상태",
@@ -49,5 +69,23 @@
     "title": "파트너 매칭",
     "submit": "파트너 등록",
     "review": "검수 상태"
+  },
+  "help": {
+    "title": "도움말 & FAQ",
+    "description": "서비스 이용 중 자주 묻는 질문을 정리했습니다.",
+    "faqs": {
+      "fundingProcess": {
+        "question": "펀딩은 어떻게 진행되나요?",
+        "answer": "프로젝트 오픈 → 팬 서포트 → 목표 달성 시 정산 및 리워드 제공 순으로 진행됩니다. Stripe 테스트 결제를 활용해 미리 시뮬레이션할 수 있습니다."
+      },
+      "partnerReview": {
+        "question": "파트너 검수는 얼마나 걸리나요?",
+        "answer": "제출 후 영업일 기준 3~5일 소요되며, 결과는 이메일로 안내드립니다."
+      },
+      "settlementReport": {
+        "question": "정산 리포트는 어디에서 확인하나요?",
+        "answer": "프로젝트 상세 페이지의 Settlement 탭에서 확인할 수 있습니다."
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- wrap the home, projects, and help pages with `useTranslation` and replace exposed copy with localization keys
- extend the section header CTA to accept translated labels and enrich both Korean/English locale dictionaries with the new text
- document the shared translation key hierarchy in the README for future contributors

## Testing
- npm run lint *(fails: existing @typescript-eslint/no-explicit-any warning in components/sections/community-board.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_68d5f94f7748832686289f6ca9352e5c