### PR TITLE
feat: enhance community board interactions

### DIFF
--- a/app/api/community/[id]/comments/route.ts
+++ b/app/api/community/[id]/comments/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { type CommunityComment } from '@/lib/data/community';
+import { prisma } from '@/lib/prisma';
+
+const DEMO_USER = {
+  id: 'demo-user',
+  name: 'Demo User',
+  email: 'demo@collaborium.ai'
+};
+
+async function ensureDemoUser() {
+  try {
+    await prisma.user.upsert({
+      where: { id: DEMO_USER.id },
+      update: { name: DEMO_USER.name, email: DEMO_USER.email },
+      create: {
+        id: DEMO_USER.id,
+        name: DEMO_USER.name,
+        email: DEMO_USER.email
+      }
+    });
+  } catch (error) {
+    console.error('[communityComment.ensureDemoUser]', error);
+  }
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const body = await request.json();
+
+  const userId = body.userId ?? DEMO_USER.id;
+
+  try {
+    await ensureDemoUser();
+
+    const comment = await prisma.comment.create({
+      data: {
+        content: body.content,
+        postId: params.id,
+        authorId: userId
+      },
+      include: {
+        author: {
+          select: {
+            id: true,
+            name: true,
+            image: true
+          }
+        }
+      }
+    });
+
+    const response: CommunityComment = {
+      id: comment.id,
+      content: comment.content,
+      createdAt: comment.createdAt.toISOString(),
+      author: comment.author
+        ? {
+            id: comment.author.id,
+            name: comment.author.name,
+            image: comment.author.image ?? null
+          }
+        : undefined
+    };
+
+    return NextResponse.json(response, { status: 201 });
+  } catch (error) {
+    console.error('[communityComment.POST]', error);
+    const fallback: CommunityComment = {
+      id: crypto.randomUUID(),
+      content: body.content,
+      createdAt: new Date().toISOString(),
+      author: {
+        id: DEMO_USER.id,
+        name: DEMO_USER.name
+      }
+    };
+    return NextResponse.json(fallback, { status: 201 });
+  }
+}

--- a/app/api/community/[id]/route.ts
+++ b/app/api/community/[id]/route.ts
@@ -1,28 +1,180 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-import { demoCommunityPosts } from '@/lib/data/community';
+import {
+  demoCommunityPosts,
+  type CommunityPost,
+  type CommunityComment
+} from '@/lib/data/community';
+import { prisma } from '@/lib/prisma';
+
+const DEMO_USER = {
+  id: 'demo-user',
+  name: 'Demo User',
+  email: 'demo@collaborium.ai'
+};
+
+function mapPost(post: any): CommunityPost {
+  const comments: CommunityComment[] = (post.comments ?? []).map((comment: any) => ({
+    id: comment.id,
+    content: comment.content,
+    createdAt: comment.createdAt?.toISOString?.() ?? comment.createdAt,
+    author: comment.author
+      ? {
+          id: comment.author.id,
+          name: comment.author.name,
+          image: comment.author.image ?? null
+        }
+      : undefined
+  }));
+
+  return {
+    id: post.id,
+    title: post.title,
+    content: post.content,
+    likes:
+      post._count?.likes ??
+      (Array.isArray(post.likes) ? post.likes.length : post.likes ?? 0),
+    commentsCount:
+      post._count?.comments ??
+      (typeof post.commentsCount === 'number'
+        ? post.commentsCount
+        : comments.length),
+    projectId: post.projectId ?? undefined,
+    createdAt: post.createdAt?.toISOString?.() ?? post.createdAt,
+    author: post.author
+      ? {
+          id: post.author.id,
+          name: post.author.name,
+          image: post.author.image ?? null
+        }
+      : undefined,
+    comments,
+    likedBy: Array.isArray(post.likedBy)
+      ? post.likedBy
+      : Array.isArray(post.likes)
+        ? post.likes.map((like: any) =>
+            typeof like === 'string' ? like : like?.userId ?? ''
+          ).filter(Boolean)
+        : []
+  };
+}
+
+async function ensureDemoUser() {
+  try {
+    await prisma.user.upsert({
+      where: { id: DEMO_USER.id },
+      update: { name: DEMO_USER.name, email: DEMO_USER.email },
+      create: {
+        id: DEMO_USER.id,
+        name: DEMO_USER.name,
+        email: DEMO_USER.email
+      }
+    });
+  } catch (error) {
+    console.error('[communityId.ensureDemoUser]', error);
+  }
+}
 
 export async function GET(
   _request: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  const post = demoCommunityPosts.find((item) => item.id === params.id);
-  if (!post) {
-    return NextResponse.json({ message: 'Post not found' }, { status: 404 });
-  }
+  try {
+    const post = await prisma.post.findUnique({
+      where: { id: params.id },
+      include: {
+        author: {
+          select: {
+            id: true,
+            name: true,
+            image: true
+          }
+        },
+        comments: {
+          orderBy: { createdAt: 'asc' },
+          include: {
+            author: {
+              select: {
+                id: true,
+                name: true,
+                image: true
+              }
+            }
+          }
+        },
+        likes: true,
+        _count: {
+          select: {
+            comments: true,
+            likes: true
+          }
+        }
+      }
+    });
 
-  return NextResponse.json(post);
+    if (!post) {
+      return NextResponse.json({ message: 'Post not found' }, { status: 404 });
+    }
+
+    return NextResponse.json(mapPost(post));
+  } catch (error) {
+    console.error('[communityId.GET]', error);
+    const fallback = demoCommunityPosts.find((item) => item.id === params.id);
+    if (!fallback) {
+      return NextResponse.json({ message: 'Post not found' }, { status: 404 });
+    }
+    return NextResponse.json(fallback);
+  }
 }
 
 export async function PATCH(
   request: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  const post = demoCommunityPosts.find((item) => item.id === params.id);
-  if (!post) {
-    return NextResponse.json({ message: 'Post not found' }, { status: 404 });
+  const body = await request.json();
+
+  if (body.action !== 'toggleLike') {
+    return NextResponse.json({ message: 'Unsupported action' }, { status: 400 });
   }
 
-  const body = await request.json();
-  return NextResponse.json({ ...post, ...body });
+  const userId = body.userId ?? DEMO_USER.id;
+
+  try {
+    await ensureDemoUser();
+
+    const existingLike = await prisma.like.findFirst({
+      where: {
+        postId: params.id,
+        userId
+      }
+    });
+
+    if (existingLike) {
+      await prisma.like.delete({
+        where: { id: existingLike.id }
+      });
+    } else {
+      await prisma.like.create({
+        data: {
+          postId: params.id,
+          userId
+        }
+      });
+    }
+
+    const likes = await prisma.like.count({
+      where: { postId: params.id }
+    });
+
+    return NextResponse.json({ liked: !existingLike, likes });
+  } catch (error) {
+    console.error('[communityId.PATCH]', error);
+    return NextResponse.json(
+      {
+        liked: body.nextLiked ?? false,
+        likes: body.nextLikes ?? body.currentLikes ?? 0
+      },
+      { status: 200 }
+    );
+  }
 }

--- a/app/api/community/route.ts
+++ b/app/api/community/route.ts
@@ -1,12 +1,202 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-import { demoCommunityPosts } from '@/lib/data/community';
+import {
+  demoCommunityPosts,
+  type CommunityPost,
+  type CommunityComment
+} from '@/lib/data/community';
+import { prisma } from '@/lib/prisma';
 
-export async function GET() {
-  return NextResponse.json(demoCommunityPosts);
+const DEMO_USER = {
+  id: 'demo-user',
+  name: 'Demo User',
+  email: 'demo@collaborium.ai'
+};
+
+function mapPostToResponse(post: any): CommunityPost {
+  const comments: CommunityComment[] = (post.comments ?? []).map((comment: any) => ({
+    id: comment.id,
+    content: comment.content,
+    createdAt: comment.createdAt?.toISOString?.() ?? comment.createdAt,
+    author: comment.author
+      ? {
+          id: comment.author.id,
+          name: comment.author.name,
+          image: comment.author.image ?? null
+        }
+      : undefined
+  }));
+
+  return {
+    id: post.id,
+    title: post.title,
+    content: post.content,
+    likes:
+      post._count?.likes ??
+      (Array.isArray(post.likes) ? post.likes.length : post.likes ?? 0),
+    commentsCount:
+      post._count?.comments ??
+      (typeof post.commentsCount === 'number'
+        ? post.commentsCount
+        : comments.length),
+    projectId: post.projectId ?? undefined,
+    createdAt: post.createdAt?.toISOString?.() ?? post.createdAt,
+    author: post.author
+      ? {
+          id: post.author.id,
+          name: post.author.name,
+          image: post.author.image ?? null
+        }
+      : undefined,
+    comments,
+    likedBy: Array.isArray(post.likedBy)
+      ? post.likedBy
+      : Array.isArray(post.likes)
+        ? post.likes.map((like: any) =>
+            typeof like === 'string' ? like : like?.userId ?? ''
+          ).filter(Boolean)
+        : []
+  };
+}
+
+async function ensureDemoUser() {
+  try {
+    await prisma.user.upsert({
+      where: { id: DEMO_USER.id },
+      update: { name: DEMO_USER.name, email: DEMO_USER.email },
+      create: {
+        id: DEMO_USER.id,
+        name: DEMO_USER.name,
+        email: DEMO_USER.email
+      }
+    });
+  } catch (error) {
+    console.error('[community.ensureDemoUser]', error);
+  }
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const projectId = searchParams.get('projectId') ?? undefined;
+
+    const posts = await prisma.post.findMany({
+      where: projectId
+        ? {
+            projectId
+          }
+        : undefined,
+      include: {
+        author: {
+          select: {
+            id: true,
+            name: true,
+            image: true
+          }
+        },
+        comments: {
+          orderBy: { createdAt: 'asc' },
+          include: {
+            author: {
+              select: {
+                id: true,
+                name: true,
+                image: true
+              }
+            }
+          }
+        },
+        likes: true,
+        _count: {
+          select: {
+            comments: true,
+            likes: true
+          }
+        }
+      },
+      orderBy: {
+        createdAt: 'desc'
+      }
+    });
+
+    return NextResponse.json(posts.map(mapPostToResponse));
+  } catch (error) {
+    console.error('[community.GET]', error);
+    return NextResponse.json(
+      demoCommunityPosts.map((post) => ({
+        ...post,
+        comments: post.comments.map((comment) => ({
+          ...comment
+        }))
+      })),
+      { status: 200 }
+    );
+  }
 }
 
 export async function POST(request: NextRequest) {
   const body = await request.json();
-  return NextResponse.json({ ...body, id: crypto.randomUUID(), likes: 0, comments: 0 }, { status: 201 });
+
+  try {
+    await ensureDemoUser();
+
+    const post = await prisma.post.create({
+      data: {
+        title: body.title,
+        content: body.content,
+        projectId: body.projectId ?? undefined,
+        authorId: body.authorId ?? DEMO_USER.id
+      },
+      include: {
+        author: {
+          select: {
+            id: true,
+            name: true,
+            image: true
+          }
+        },
+        comments: {
+          orderBy: { createdAt: 'asc' },
+          include: {
+            author: {
+              select: {
+                id: true,
+                name: true,
+                image: true
+              }
+            }
+          }
+        },
+        likes: true,
+        _count: {
+          select: {
+            comments: true,
+            likes: true
+          }
+        }
+      }
+    });
+
+    return NextResponse.json(mapPostToResponse(post), { status: 201 });
+  } catch (error) {
+    console.error('[community.POST]', error);
+    return NextResponse.json(
+      {
+        id: crypto.randomUUID(),
+        title: body.title,
+        content: body.content,
+        projectId: body.projectId ?? undefined,
+        createdAt: new Date().toISOString(),
+        likes: 0,
+        commentsCount: 0,
+        comments: [],
+        likedBy: [],
+        author: {
+          id: DEMO_USER.id,
+          name: DEMO_USER.name
+        }
+      },
+      { status: 201 }
+    );
+  }
 }

--- a/components/sections/community-board.tsx
+++ b/components/sections/community-board.tsx
@@ -1,36 +1,352 @@
 'use client';
 
-import { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { Heart, MessageCircle } from 'lucide-react';
+import { FormEvent, useMemo, useState } from 'react';
+import {
+  useMutation,
+  useQuery,
+  useQueryClient
+} from '@tanstack/react-query';
+import { Heart, Loader2, MessageCircle } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
-import { demoCommunityPosts } from '@/lib/data/community';
+import {
+  demoCommunityPosts,
+  type CommunityPost,
+  type CommunityComment
+} from '@/lib/data/community';
 
 export function CommunityBoard({ projectId }: { projectId?: string }) {
   const { t } = useTranslation();
+  const queryClient = useQueryClient();
   const [sort, setSort] = useState<'recent' | 'popular'>('recent');
-  const { data: posts = [] } = useQuery({
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [commentDrafts, setCommentDrafts] = useState<Record<string, string>>({});
+
+  const currentUserId = 'demo-user';
+
+  const normalizePost = (post: any): CommunityPost => {
+    const rawComments = Array.isArray(post?.comments) ? post.comments : [];
+    const normalizedComments: CommunityComment[] = rawComments.map((comment: any) => ({
+      id: comment.id,
+      content: comment.content,
+      createdAt:
+        typeof comment.createdAt === 'string'
+          ? comment.createdAt
+          : comment.createdAt?.toISOString?.() ?? undefined,
+      author: comment.author
+        ? {
+            id: comment.author.id,
+            name: comment.author.name,
+            image: comment.author.image ?? null
+          }
+        : undefined
+    }));
+
+    const likedBy = Array.isArray(post?.likedBy)
+      ? post.likedBy
+      : Array.isArray(post?.likes)
+        ? post.likes.map((like: any) =>
+            typeof like === 'string' ? like : like?.userId ?? currentUserId
+          )
+        : [];
+
+    return {
+      id: post.id,
+      title: post.title,
+      content: post.content,
+      likes: typeof post.likes === 'number' ? post.likes : post._count?.likes ?? likedBy.length ?? 0,
+      commentsCount:
+        typeof post.commentsCount === 'number'
+          ? post.commentsCount
+          : post._count?.comments ?? normalizedComments.length,
+      projectId: post.projectId ?? undefined,
+      createdAt:
+        typeof post.createdAt === 'string'
+          ? post.createdAt
+          : post.createdAt?.toISOString?.(),
+      author: post.author
+        ? {
+            id: post.author.id,
+            name: post.author.name,
+            image: post.author.image ?? null
+          }
+        : undefined,
+      comments: normalizedComments,
+      likedBy
+    };
+  };
+
+  const { data: posts = [] } = useQuery<CommunityPost[]>({
     queryKey: ['community', projectId],
     queryFn: async () => {
-      const res = await fetch('/api/community');
-      if (!res.ok) {
-        return demoCommunityPosts;
+      try {
+        const params = projectId
+          ? `?${new URLSearchParams({ projectId }).toString()}`
+          : '';
+        const res = await fetch(`/api/community${params}`);
+        if (!res.ok) {
+          throw new Error('Failed to fetch posts');
+        }
+        const json = await res.json();
+        const list = Array.isArray(json) ? json : demoCommunityPosts;
+        return list
+          .filter((item) =>
+            projectId ? item.projectId === projectId : true
+          )
+          .map(normalizePost);
+      } catch (error) {
+        console.error('[CommunityBoard] Failed to fetch posts', error);
+        return demoCommunityPosts
+          .filter((item) => (projectId ? item.projectId === projectId : true))
+          .map(normalizePost);
       }
-      const json = await res.json();
-      return projectId ? json.filter((item: any) => item.projectId === projectId) : json;
     }
   });
 
-  const sorted = [...posts].sort((a, b) => {
-    if (sort === 'popular') {
-      return b.likes - a.likes;
+  const createPostMutation = useMutation<CommunityPost, Error, { title: string; content: string }>(
+    {
+      mutationFn: async ({ title: postTitle, content: postContent }) => {
+        const res = await fetch('/api/community', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({
+            title: postTitle,
+            content: postContent,
+            projectId,
+            authorId: currentUserId
+          })
+        });
+
+        if (!res.ok) {
+          throw new Error('Failed to create community post');
+        }
+
+        return normalizePost(await res.json());
+      },
+      onSuccess: (newPost) => {
+        queryClient.setQueryData<CommunityPost[]>(['community', projectId], (prev = []) => {
+          if (projectId && newPost.projectId && newPost.projectId !== projectId) {
+            return prev;
+          }
+          return [newPost, ...prev];
+        });
+        setTitle('');
+        setContent('');
+      }
     }
-    return new Date(b.createdAt ?? Date.now()).valueOf() - new Date(a.createdAt ?? Date.now()).valueOf();
+  );
+
+  const commentMutation = useMutation<CommunityComment, Error, { postId: string; content: string }>(
+    {
+      mutationFn: async ({ postId, content }) => {
+        const res = await fetch(`/api/community/${postId}/comments`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({
+            content,
+            userId: currentUserId
+          })
+        });
+
+        if (!res.ok) {
+          throw new Error('Failed to add comment');
+        }
+
+        const comment = await res.json();
+        return {
+          id: comment.id,
+          content: comment.content,
+          createdAt: comment.createdAt,
+          author: comment.author
+            ? {
+                id: comment.author.id,
+                name: comment.author.name,
+                image: comment.author.image ?? null
+              }
+            : undefined
+        } satisfies CommunityComment;
+      },
+      onSuccess: (comment, { postId }) => {
+        queryClient.setQueryData<CommunityPost[]>(['community', projectId], (prev = []) =>
+          prev.map((post) =>
+            post.id === postId
+              ? {
+                  ...post,
+                  comments: [...post.comments, comment],
+                  commentsCount: (post.commentsCount ?? post.comments.length) + 1
+                }
+              : post
+          )
+        );
+        setCommentDrafts((prev) => ({ ...prev, [postId]: '' }));
+      }
+    }
+  );
+
+  const likeMutation = useMutation<
+    { liked?: boolean; likes?: number },
+    Error,
+    { postId: string; nextLiked: boolean; nextLikes: number; currentLikes: number },
+    { previousPosts?: CommunityPost[] }
+  >({
+    mutationFn: async ({ postId, nextLiked, nextLikes, currentLikes }) => {
+      const res = await fetch(`/api/community/${postId}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          action: 'toggleLike',
+          userId: currentUserId,
+          nextLiked,
+          nextLikes,
+          currentLikes
+        })
+      });
+
+      if (!res.ok) {
+        throw new Error('Failed to toggle like');
+      }
+
+      return res.json();
+    },
+    onMutate: async (variables) => {
+      await queryClient.cancelQueries({ queryKey: ['community', projectId] });
+      const previousPosts = queryClient.getQueryData<CommunityPost[]>(['community', projectId]);
+
+      queryClient.setQueryData<CommunityPost[]>(['community', projectId], (prev = []) =>
+        prev.map((post) =>
+          post.id === variables.postId
+            ? {
+                ...post,
+                likes: variables.nextLikes,
+                likedBy: variables.nextLiked
+                  ? Array.from(new Set([...(post.likedBy ?? []), currentUserId]))
+                  : (post.likedBy ?? []).filter((id) => id !== currentUserId)
+              }
+            : post
+        )
+      );
+
+      return { previousPosts };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previousPosts) {
+        queryClient.setQueryData(['community', projectId], context.previousPosts);
+      }
+    },
+    onSuccess: (data, variables) => {
+      queryClient.setQueryData<CommunityPost[]>(['community', projectId], (prev = []) =>
+        prev.map((post) => {
+          if (post.id !== variables.postId) {
+            return post;
+          }
+
+          const liked = data.liked ?? variables.nextLiked;
+          const likes = typeof data.likes === 'number' ? data.likes : variables.nextLikes;
+
+          return {
+            ...post,
+            likes,
+            likedBy: liked
+              ? Array.from(new Set([...(post.likedBy ?? []), currentUserId]))
+              : (post.likedBy ?? []).filter((id) => id !== currentUserId)
+          };
+        })
+      );
+    }
   });
+
+  const sorted = useMemo(() => {
+    return [...posts].sort((a, b) => {
+      if (sort === 'popular') {
+        return b.likes - a.likes;
+      }
+
+      return (
+        new Date(b.createdAt ?? Date.now()).valueOf() -
+        new Date(a.createdAt ?? Date.now()).valueOf()
+      );
+    });
+  }, [posts, sort]);
+
+  const handleCreatePost = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!title.trim() || !content.trim()) {
+      return;
+    }
+    createPostMutation.mutate({ title: title.trim(), content: content.trim() });
+  };
+
+  const handleCommentSubmit = (
+    event: FormEvent<HTMLFormElement>,
+    post: CommunityPost
+  ) => {
+    event.preventDefault();
+    const draft = (commentDrafts[post.id] ?? '').trim();
+    if (!draft) {
+      return;
+    }
+    commentMutation.mutate({ postId: post.id, content: draft });
+  };
+
+  const handleToggleLike = (post: CommunityPost) => {
+    const isLiked = (post.likedBy ?? []).includes(currentUserId);
+    const nextLiked = !isLiked;
+    const nextLikes = nextLiked
+      ? post.likes + 1
+      : Math.max(0, post.likes - 1);
+
+    likeMutation.mutate({
+      postId: post.id,
+      nextLiked,
+      nextLikes,
+      currentLikes: post.likes
+    });
+  };
 
   return (
     <section className="space-y-6">
+      <form
+        onSubmit={handleCreatePost}
+        className="rounded-3xl border border-white/10 bg-white/5 p-6 shadow-[0_20px_40px_rgba(15,23,42,0.35)] backdrop-blur"
+      >
+        <div className="flex flex-col gap-4">
+          <input
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+            placeholder={t('community.titlePlaceholder', '제목을 입력하세요')}
+            className="w-full rounded-2xl border border-white/10 bg-black/20 px-4 py-3 text-sm text-white placeholder:text-white/40 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+          />
+          <textarea
+            value={content}
+            onChange={(event) => setContent(event.target.value)}
+            placeholder={t('community.contentPlaceholder')}
+            className="min-h-[120px] w-full resize-y rounded-2xl border border-white/10 bg-black/20 px-4 py-3 text-sm text-white placeholder:text-white/40 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+          />
+          <div className="flex items-center justify-end gap-3">
+            <button
+              type="submit"
+              disabled={
+                createPostMutation.isPending ||
+                !title.trim() ||
+                !content.trim()
+              }
+              className="inline-flex items-center gap-2 rounded-full bg-primary px-5 py-2 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:bg-white/10 disabled:text-white/40"
+            >
+              {createPostMutation.isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : null}
+              {t('community.post')}
+            </button>
+          </div>
+        </div>
+      </form>
       <div className="flex items-center gap-3">
         <button
           type="button"
@@ -49,21 +365,122 @@ export function CommunityBoard({ projectId }: { projectId?: string }) {
       </div>
       <div className="space-y-4">
         {sorted.map((post) => (
-          <article key={post.id} className="rounded-3xl border border-white/10 bg-white/5 p-6">
-            <header className="flex items-center justify-between">
-              <h3 className="text-lg font-semibold text-white">{post.title}</h3>
+          <article
+            key={post.id}
+            className="rounded-3xl border border-white/10 bg-white/5 p-6"
+          >
+            <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h3 className="text-lg font-semibold text-white">{post.title}</h3>
+                {post.author ? (
+                  <p className="text-xs text-white/50">
+                    {post.author.name}
+                  </p>
+                ) : null}
+              </div>
               <div className="flex items-center gap-4 text-sm text-white/60">
-                <span className="inline-flex items-center gap-1">
-                  <Heart className="h-4 w-4" />
+                <button
+                  type="button"
+                  onClick={() => handleToggleLike(post)}
+                  disabled={
+                    likeMutation.isPending &&
+                    likeMutation.variables?.postId === post.id
+                  }
+                  className={`inline-flex items-center gap-1 rounded-full px-3 py-1 transition ${
+                    (post.likedBy ?? []).includes(currentUserId)
+                      ? 'bg-primary/10 text-primary'
+                      : 'bg-white/5 text-white/70 hover:bg-white/10'
+                  } disabled:cursor-not-allowed disabled:opacity-60`}
+                >
+                  <Heart
+                    className="h-4 w-4"
+                    fill={
+                      (post.likedBy ?? []).includes(currentUserId)
+                        ? 'currentColor'
+                        : 'none'
+                    }
+                  />
                   {post.likes}
-                </span>
+                </button>
                 <span className="inline-flex items-center gap-1">
                   <MessageCircle className="h-4 w-4" />
-                  {post.comments}
+                  {post.commentsCount ?? post.comments.length}
                 </span>
               </div>
             </header>
-            <p className="mt-3 text-sm text-white/70">{post.content}</p>
+            <p className="mt-3 text-sm text-white/70 whitespace-pre-wrap">{post.content}</p>
+
+            <div className="mt-6 space-y-4">
+              <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-wide text-white/40">
+                <span>
+                  {t('community.commentsLabel', '댓글')} ·{' '}
+                  {post.commentsCount ?? post.comments.length}
+                </span>
+                <span className="text-white/30">
+                  {new Date(post.createdAt ?? Date.now()).toLocaleString()}
+                </span>
+              </div>
+              <ul className="space-y-3">
+                {post.comments.length > 0 ? (
+                  post.comments.map((comment) => (
+                    <li
+                      key={comment.id}
+                      className="rounded-2xl border border-white/5 bg-black/30 p-4"
+                    >
+                      <div className="flex items-center justify-between text-xs text-white/50">
+                        <span>{comment.author?.name ?? t('community.anonymous', '익명')}</span>
+                        <span>
+                          {comment.createdAt
+                            ? new Date(comment.createdAt).toLocaleString()
+                            : ''}
+                        </span>
+                      </div>
+                      <p className="mt-2 text-sm text-white/80 whitespace-pre-wrap">
+                        {comment.content}
+                      </p>
+                    </li>
+                  ))
+                ) : (
+                  <li className="rounded-2xl border border-white/5 bg-black/30 p-4 text-sm text-white/50">
+                    {t('community.emptyComments', '첫 번째 댓글을 남겨보세요.')} 
+                  </li>
+                )}
+              </ul>
+              <form
+                onSubmit={(event) => handleCommentSubmit(event, post)}
+                className="flex flex-col gap-3 rounded-2xl border border-white/10 bg-black/30 p-4"
+              >
+                <textarea
+                  value={commentDrafts[post.id] ?? ''}
+                  onChange={(event) =>
+                    setCommentDrafts((prev) => ({
+                      ...prev,
+                      [post.id]: event.target.value
+                    }))
+                  }
+                  placeholder={t('community.commentPlaceholder')}
+                  className="min-h-[80px] w-full resize-y rounded-xl border border-white/10 bg-transparent px-3 py-2 text-sm text-white placeholder:text-white/40 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+                />
+                <div className="flex justify-end">
+                  <button
+                    type="submit"
+                    disabled={
+                      commentMutation.isPending &&
+                      commentMutation.variables?.postId === post.id
+                        ? true
+                        : !(commentDrafts[post.id] ?? '').trim()
+                    }
+                    className="inline-flex items-center gap-2 rounded-full bg-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-white/80 transition hover:bg-white/20 disabled:cursor-not-allowed disabled:text-white/30"
+                  >
+                    {commentMutation.isPending &&
+                    commentMutation.variables?.postId === post.id ? (
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    ) : null}
+                    {t('community.commentSubmit', '댓글 달기')}
+                  </button>
+                </div>
+              </form>
+            </div>
           </article>
         ))}
       </div>

--- a/lib/data/community.ts
+++ b/lib/data/community.ts
@@ -1,10 +1,27 @@
+export interface CommunityAuthor {
+  id: string;
+  name: string;
+  image?: string | null;
+}
+
+export interface CommunityComment {
+  id: string;
+  content: string;
+  createdAt?: string;
+  author?: CommunityAuthor;
+}
+
 export interface CommunityPost {
   id: string;
   title: string;
   content: string;
   likes: number;
-  comments: number;
+  commentsCount: number;
   projectId?: string;
+  createdAt?: string;
+  author?: CommunityAuthor;
+  comments: CommunityComment[];
+  likedBy: string[];
 }
 
 export const demoCommunityPosts: CommunityPost[] = [
@@ -13,15 +30,58 @@ export const demoCommunityPosts: CommunityPost[] = [
     title: '팬 참여형 콘셉트 아이디어 공유',
     content: '실시간 참여 투표로 스토리를 완성하는 공연을 제안합니다.',
     likes: 54,
-    comments: 12,
-    projectId: '1'
+    commentsCount: 2,
+    projectId: '1',
+    createdAt: new Date().toISOString(),
+    author: {
+      id: 'demo-user',
+      name: '홍길동'
+    },
+    likedBy: ['demo-user', 'fan-1', 'fan-2'],
+    comments: [
+      {
+        id: 'comment-1',
+        content: '이 아이디어 정말 신선하네요! 참여하고 싶어요.',
+        createdAt: new Date().toISOString(),
+        author: {
+          id: 'fan-3',
+          name: '팬 A'
+        }
+      },
+      {
+        id: 'comment-2',
+        content: '투표로 결말이 바뀌는 공연이라니 기대됩니다.',
+        createdAt: new Date().toISOString(),
+        author: {
+          id: 'fan-4',
+          name: '팬 B'
+        }
+      }
+    ]
   },
   {
     id: 'post-2',
     title: '굿즈 투표 결과 공개',
     content: '아티스트와 함께 만든 한정판 의상 굿즈 결과를 확인하세요!',
     likes: 34,
-    comments: 4,
-    projectId: '2'
+    commentsCount: 1,
+    projectId: '2',
+    createdAt: new Date().toISOString(),
+    author: {
+      id: 'demo-user',
+      name: '콜라보 운영팀'
+    },
+    likedBy: ['fan-5', 'fan-6'],
+    comments: [
+      {
+        id: 'comment-3',
+        content: '결과 공유 감사합니다! 배송 일정도 알려주세요.',
+        createdAt: new Date().toISOString(),
+        author: {
+          id: 'fan-7',
+          name: '팬 C'
+        }
+      }
+    ]
   }
 ];

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,11 @@
+import { PrismaClient } from '@prisma/client';
+
+const globalForPrisma = globalThis as unknown as {
+  prisma?: PrismaClient;
+};
+
+export const prisma = globalForPrisma.prisma ?? new PrismaClient();
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForPrisma.prisma = prisma;
+}

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -43,7 +43,14 @@
     "writePlaceholder": "Share something with the community",
     "sortRecent": "Recent",
     "sortPopular": "Popular",
-    "post": "Post"
+    "post": "Post",
+    "titlePlaceholder": "Give your post a title",
+    "contentPlaceholder": "Share something with the community",
+    "commentPlaceholder": "Join the conversation",
+    "commentsLabel": "Comments",
+    "anonymous": "Anonymous",
+    "emptyComments": "Be the first to respond.",
+    "commentSubmit": "Add comment"
   },
   "partners": {
     "title": "Partner matching",

--- a/locales/ko/common.json
+++ b/locales/ko/common.json
@@ -43,7 +43,14 @@
     "writePlaceholder": "커뮤니티에 이야기를 공유하세요",
     "sortRecent": "최신순",
     "sortPopular": "인기순",
-    "post": "게시하기"
+    "post": "게시하기",
+    "titlePlaceholder": "제목을 입력하세요",
+    "contentPlaceholder": "커뮤니티에 이야기를 공유하세요",
+    "commentPlaceholder": "응원의 댓글을 남겨보세요",
+    "commentsLabel": "댓글",
+    "anonymous": "익명",
+    "emptyComments": "첫 번째 댓글을 남겨보세요.",
+    "commentSubmit": "댓글 달기"
   },
   "partners": {
     "title": "파트너 매칭",


### PR DESCRIPTION
## Summary
- add Prisma client helpers and upgrade community APIs to persist posts, comments, and likes with graceful demo fallbacks
- introduce comment creation endpoint and extend sample community data to include structured authors, likes, and comments
- redesign the community board with React Query mutations for posting, commenting, liking, and refreshed i18n copy

## Testing
- npm run lint *(fails: next binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d5f94adb1c83269683ce1abfcc0a91