### PR TITLE
Localize community copy and footer strings

### DIFF
--- a/app/community/page.tsx
+++ b/app/community/page.tsx
@@ -1,13 +1,17 @@
+'use client';
+
+import { useTranslation } from 'react-i18next';
+
 import { CommunityBoard } from '@/components/sections/community-board';
 
 export default function CommunityPage() {
+  const { t } = useTranslation();
+
   return (
     <div className="mx-auto max-w-5xl px-4 pb-20">
       <header className="pt-6">
-        <h1 className="text-3xl font-semibold text-white">커뮤니티</h1>
-        <p className="mt-2 text-sm text-white/60">
-          프로젝트 후원자들과 실시간으로 소통하고, 아이디어와 피드백을 공유하세요.
-        </p>
+        <h1 className="text-3xl font-semibold text-white">{t('community.title')}</h1>
+        <p className="mt-2 text-sm text-white/60">{t('community.description')}</p>
       </header>
       <section className="mt-10">
         <CommunityBoard />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -60,7 +60,11 @@ export default function HomePage() {
           </h3>
           <p className="text-2xl font-semibold text-white">{t('home.liveAma.title')}</p>
           <p className="text-sm text-white/60">{t('home.liveAma.description')}</p>
-          <Link href="/projects/1" className="inline-flex w-fit rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground">
+          <Link
+            href="/projects/1"
+            className="inline-flex w-fit rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground"
+            aria-label={t('home.liveAma.ctaAria', { title: t('home.liveAma.title') })}
+          >
             {t('home.liveAma.cta')}
           </Link>
         </div>

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -1,58 +1,68 @@
+'use client';
+
 import Link from 'next/link';
+import { useTranslation } from 'react-i18next';
 
 export function Footer() {
+  const { t } = useTranslation();
+  const year = new Date().getFullYear();
+
   return (
     <footer className="border-t border-white/10 bg-neutral-950/80 py-10">
       <div className="mx-auto grid max-w-7xl gap-8 px-4 text-sm text-white/70 md:grid-cols-4">
         <div>
-          <h3 className="text-base font-semibold text-white">Collaborium</h3>
-          <p className="mt-3 text-white/60">
-            아티스트와 팬이 함께 성장하는 팬메이드 펀딩 플랫폼.
-          </p>
+          <h3 className="text-base font-semibold text-white">{t('footer.brand.name')}</h3>
+          <p className="mt-3 text-white/60">{t('footer.brand.description')}</p>
         </div>
         <div className="space-y-2">
-          <h4 className="text-xs font-semibold uppercase tracking-wider text-white/70">Platform</h4>
+          <h4 className="text-xs font-semibold uppercase tracking-wider text-white/70">
+            {t('footer.sections.platform.title')}
+          </h4>
           <ul className="space-y-1">
             <li>
               <Link href="/projects" className="hover:text-white">
-                프로젝트
+                {t('navigation.projects')}
               </Link>
             </li>
             <li>
               <Link href="/partners" className="hover:text-white">
-                파트너
+                {t('navigation.partners')}
               </Link>
             </li>
             <li>
               <Link href="/community" className="hover:text-white">
-                커뮤니티
+                {t('navigation.community')}
               </Link>
             </li>
           </ul>
         </div>
         <div className="space-y-2">
-          <h4 className="text-xs font-semibold uppercase tracking-wider text-white/70">Support</h4>
+          <h4 className="text-xs font-semibold uppercase tracking-wider text-white/70">
+            {t('footer.sections.support.title')}
+          </h4>
           <ul className="space-y-1">
             <li>
               <Link href="/help" className="hover:text-white">
-                도움말 센터
+                {t('footer.sections.support.links.help')}
               </Link>
             </li>
             <li>
               <Link href="/partners" className="hover:text-white">
-                파트너 가입
+                {t('footer.sections.support.links.partnerJoin')}
               </Link>
             </li>
           </ul>
         </div>
         <div className="space-y-2">
-          <h4 className="text-xs font-semibold uppercase tracking-wider text-white/70">Contact</h4>
-          <p>contact@collaborium.kr</p>
-          <p>서울시 성동구 성수이로 00</p>
+          <h4 className="text-xs font-semibold uppercase tracking-wider text-white/70">
+            {t('footer.sections.contact.title')}
+          </h4>
+          <p>{t('footer.sections.contact.email')}</p>
+          <p>{t('footer.sections.contact.address')}</p>
         </div>
       </div>
       <div className="mt-10 border-t border-white/10 pt-6 text-center text-xs text-white/50">
-        © {new Date().getFullYear()} Collaborium. All rights reserved.
+        {t('footer.copyright', { year })}
       </div>
     </footer>
   );

--- a/components/shared/section-header.tsx
+++ b/components/shared/section-header.tsx
@@ -1,5 +1,8 @@
+'use client';
+
 import Link from 'next/link';
 import { ArrowUpRight } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 
 interface SectionHeaderProps {
   title: string;
@@ -8,6 +11,8 @@ interface SectionHeaderProps {
 }
 
 export function SectionHeader({ title, href, ctaLabel }: SectionHeaderProps) {
+  const { t } = useTranslation();
+
   return (
     <div className="mb-6 flex items-center justify-between">
       <h2 className="text-xl font-semibold text-white">{title}</h2>
@@ -15,8 +20,9 @@ export function SectionHeader({ title, href, ctaLabel }: SectionHeaderProps) {
         <Link
           href={href}
           className="inline-flex items-center gap-1 text-sm text-white/60 transition hover:text-white"
+          aria-label={t('sectionHeader.viewMoreAria', { title })}
         >
-          {ctaLabel ?? '더 보기'}
+          {ctaLabel ?? t('actions.viewMore')}
           <ArrowUpRight className="h-4 w-4" />
         </Link>
       ) : null}

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -24,6 +24,9 @@
     "fundNow": "Fund now",
     "requestQuote": "Request quote"
   },
+  "sectionHeader": {
+    "viewMoreAria": "View more from the {{title}} section"
+  },
   "home": {
     "heroTitle": "Co-create immersive experiences with the artists you love",
     "heroSubtitle": "Discover trending projects, premium classes and live AMA events.",
@@ -44,7 +47,8 @@
       "tag": "Live AMA",
       "title": "This week's live class",
       "description": "Join an intimate AMA session with the artist. Reserve now to secure the early-bird perks.",
-      "cta": "Reserve a spot"
+      "cta": "Reserve a spot",
+      "ctaAria": "Reserve a spot for {{title}}"
     }
   },
   "projects": {
@@ -60,6 +64,8 @@
     "newest": "Newest"
   },
   "community": {
+    "title": "Community",
+    "description": "Connect with fellow backers in real time to share ideas and feedback.",
     "writePlaceholder": "Share something with the community",
     "sortRecent": "Recent",
     "sortPopular": "Popular",
@@ -87,5 +93,34 @@
         "answer": "Go to the Settlement tab on the project detail page to access the reports."
       }
     }
+  },
+  "footer": {
+    "brand": {
+      "name": "Collaborium",
+      "description": "A fan-made funding platform where artists and fans grow together."
+    },
+    "sections": {
+      "platform": {
+        "title": "Platform",
+        "links": {
+          "projects": "Projects",
+          "partners": "Partners",
+          "community": "Community"
+        }
+      },
+      "support": {
+        "title": "Support",
+        "links": {
+          "help": "Help center",
+          "partnerJoin": "Become a partner"
+        }
+      },
+      "contact": {
+        "title": "Contact",
+        "email": "contact@collaborium.kr",
+        "address": "Seongsu-ro, Seongdong-gu, Seoul"
+      }
+    },
+    "copyright": "© {{year}} Collaborium. All rights reserved."
   }
 }

--- a/locales/ko/common.json
+++ b/locales/ko/common.json
@@ -24,6 +24,9 @@
     "fundNow": "지금 후원하기",
     "requestQuote": "견적 요청"
   },
+  "sectionHeader": {
+    "viewMoreAria": "{{title}} 섹션 더 보기"
+  },
   "home": {
     "heroTitle": "아티스트와 팬이 함께 만드는 새로운 경험",
     "heroSubtitle": "실시간 인기 프로젝트와 프리미엄 클래스를 만나보세요.",
@@ -44,7 +47,8 @@
       "tag": "Live AMA",
       "title": "이번 주 라이브 클래스",
       "description": "아티스트와 직접 소통하는 원더월 스타일 AMA 세션. 지금 예약하면 얼리버드 혜택을 드립니다.",
-      "cta": "참가 신청"
+      "cta": "참가 신청",
+      "ctaAria": "{{title}} 참가 신청"
     }
   },
   "projects": {
@@ -60,6 +64,8 @@
     "newest": "최신순"
   },
   "community": {
+    "title": "커뮤니티",
+    "description": "프로젝트 후원자들과 실시간으로 소통하고, 아이디어와 피드백을 공유하세요.",
     "writePlaceholder": "커뮤니티에 이야기를 공유하세요",
     "sortRecent": "최신순",
     "sortPopular": "인기순",
@@ -87,5 +93,34 @@
         "answer": "프로젝트 상세 페이지의 Settlement 탭에서 확인할 수 있습니다."
       }
     }
+  },
+  "footer": {
+    "brand": {
+      "name": "Collaborium",
+      "description": "아티스트와 팬이 함께 성장하는 팬메이드 펀딩 플랫폼."
+    },
+    "sections": {
+      "platform": {
+        "title": "Platform",
+        "links": {
+          "projects": "프로젝트",
+          "partners": "파트너",
+          "community": "커뮤니티"
+        }
+      },
+      "support": {
+        "title": "Support",
+        "links": {
+          "help": "도움말 센터",
+          "partnerJoin": "파트너 가입"
+        }
+      },
+      "contact": {
+        "title": "Contact",
+        "email": "contact@collaborium.kr",
+        "address": "서울시 성동구 성수이로 00"
+      }
+    },
+    "copyright": "© {{year}} Collaborium. All rights reserved."
   }
 }


### PR DESCRIPTION
## Summary
- replace community and footer content with i18next translations and reusable keys
- add shared translation entries for section header aria labels and live AMA button text
- expose locale data for footer metadata in both English and Korean

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d5fea8638483268238f83a009e11fb