### PR TITLE
Persist collaboration APIs with Prisma-backed data

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,9 +1,9 @@
-import NextAuth from 'next-auth';
+import NextAuth, { type NextAuthOptions } from 'next-auth';
 import CredentialsProvider from 'next-auth/providers/credentials';
 import GoogleProvider from 'next-auth/providers/google';
 import KakaoProvider from 'next-auth/providers/kakao';
 
-const handler = NextAuth({
+export const authOptions: NextAuthOptions = {
   session: {
     strategy: 'jwt'
   },
@@ -50,6 +50,8 @@ const handler = NextAuth({
       return token;
     }
   }
-});
+};
+
+const handler = NextAuth(authOptions);
 
 export { handler as GET, handler as POST };

--- a/app/api/community/[id]/route.ts
+++ b/app/api/community/[id]/route.ts
@@ -1,28 +1,180 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-import { demoCommunityPosts } from '@/lib/data/community';
+import prisma from '@/lib/prisma';
+import { AuthenticationError, requireUser } from '@/lib/auth/session';
+
+function buildError(message: string, status = 400) {
+  return NextResponse.json({ error: message }, { status });
+}
+
+function mapPost(post: {
+  id: string;
+  title: string;
+  content: string;
+  projectId: string | null;
+  createdAt: Date;
+  author: { id: string; name: string | null; email: string } | null;
+  _count: { likes: number; comments: number };
+}) {
+  return {
+    id: post.id,
+    title: post.title,
+    content: post.content,
+    projectId: post.projectId ?? undefined,
+    createdAt: post.createdAt,
+    likes: post._count.likes,
+    comments: post._count.comments,
+    author: post.author
+      ? {
+          id: post.author.id,
+          name: post.author.name,
+          email: post.author.email
+        }
+      : undefined
+  };
+}
+
+async function resolvePost(id: string) {
+  return prisma.post.findUnique({
+    where: { id },
+    include: {
+      author: {
+        select: {
+          id: true,
+          name: true,
+          email: true
+        }
+      },
+      _count: {
+        select: {
+          likes: true,
+          comments: true
+        }
+      }
+    }
+  });
+}
 
 export async function GET(
   _request: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  const post = demoCommunityPosts.find((item) => item.id === params.id);
+  const post = await resolvePost(params.id);
   if (!post) {
-    return NextResponse.json({ message: 'Post not found' }, { status: 404 });
+    return buildError('게시글을 찾을 수 없습니다.', 404);
   }
 
-  return NextResponse.json(post);
+  return NextResponse.json(mapPost(post));
 }
 
 export async function PATCH(
   request: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  const post = demoCommunityPosts.find((item) => item.id === params.id);
+  const post = await resolvePost(params.id);
   if (!post) {
-    return NextResponse.json({ message: 'Post not found' }, { status: 404 });
+    return buildError('게시글을 찾을 수 없습니다.', 404);
   }
 
-  const body = await request.json();
-  return NextResponse.json({ ...post, ...body });
+  let user;
+  try {
+    ({ user } = await requireUser());
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      return buildError(error.message, error.status);
+    }
+    throw error;
+  }
+
+  if (!post.author || post.author.id !== user.id) {
+    return buildError('게시글을 수정할 권한이 없습니다.', 403);
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return buildError('요청 본문을 확인할 수 없습니다.');
+  }
+
+  const data: { title?: string; content?: string; projectId?: string | null } = {};
+
+  if (typeof body.title === 'string' && body.title.trim()) {
+    data.title = body.title.trim();
+  }
+
+  if (typeof body.content === 'string' && body.content.trim()) {
+    data.content = body.content.trim();
+  }
+
+  if (body.projectId !== undefined) {
+    if (body.projectId === null) {
+      data.projectId = null;
+    } else if (typeof body.projectId === 'string') {
+      const projectId = body.projectId.trim();
+      if (!projectId) {
+        data.projectId = null;
+      } else {
+        const project = await prisma.project.findUnique({ where: { id: projectId } });
+        if (!project) {
+          return buildError('연결된 프로젝트를 찾을 수 없습니다.', 404);
+        }
+        data.projectId = projectId;
+      }
+    }
+  }
+
+  if (Object.keys(data).length === 0) {
+    return buildError('변경할 항목을 확인할 수 없습니다.', 422);
+  }
+
+  const updated = await prisma.post.update({
+    where: { id: params.id },
+    data,
+    include: {
+      author: {
+        select: {
+          id: true,
+          name: true,
+          email: true
+        }
+      },
+      _count: {
+        select: {
+          likes: true,
+          comments: true
+        }
+      }
+    }
+  });
+
+  return NextResponse.json(mapPost(updated));
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const post = await resolvePost(params.id);
+  if (!post) {
+    return buildError('게시글을 찾을 수 없습니다.', 404);
+  }
+
+  let user;
+  try {
+    ({ user } = await requireUser());
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      return buildError(error.message, error.status);
+    }
+    throw error;
+  }
+
+  if (!post.author || post.author.id !== user.id) {
+    return buildError('게시글을 삭제할 권한이 없습니다.', 403);
+  }
+
+  await prisma.post.delete({ where: { id: params.id } });
+
+  return NextResponse.json({ message: 'Deleted' });
 }

--- a/app/api/community/route.ts
+++ b/app/api/community/route.ts
@@ -1,12 +1,119 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-import { demoCommunityPosts } from '@/lib/data/community';
+import prisma from '@/lib/prisma';
+import { AuthenticationError, requireUser } from '@/lib/auth/session';
+
+function buildError(message: string, status = 400) {
+  return NextResponse.json({ error: message }, { status });
+}
+
+function mapPost(post: {
+  id: string;
+  title: string;
+  content: string;
+  projectId: string | null;
+  createdAt: Date;
+  author: { id: string; name: string | null; email: string } | null;
+  _count: { likes: number; comments: number };
+}) {
+  return {
+    id: post.id,
+    title: post.title,
+    content: post.content,
+    projectId: post.projectId ?? undefined,
+    createdAt: post.createdAt,
+    likes: post._count.likes,
+    comments: post._count.comments,
+    author: post.author
+      ? {
+          id: post.author.id,
+          name: post.author.name,
+          email: post.author.email
+        }
+      : undefined
+  };
+}
 
 export async function GET() {
-  return NextResponse.json(demoCommunityPosts);
+  const posts = await prisma.post.findMany({
+    include: {
+      author: {
+        select: {
+          id: true,
+          name: true,
+          email: true
+        }
+      },
+      _count: {
+        select: {
+          likes: true,
+          comments: true
+        }
+      }
+    },
+    orderBy: { createdAt: 'desc' }
+  });
+
+  return NextResponse.json(posts.map(mapPost));
 }
 
 export async function POST(request: NextRequest) {
-  const body = await request.json();
-  return NextResponse.json({ ...body, id: crypto.randomUUID(), likes: 0, comments: 0 }, { status: 201 });
+  let body: Record<string, unknown>;
+
+  try {
+    body = await request.json();
+  } catch {
+    return buildError('요청 본문을 확인할 수 없습니다.');
+  }
+
+  const title = typeof body.title === 'string' ? body.title.trim() : '';
+  const content = typeof body.content === 'string' ? body.content.trim() : '';
+  const projectId = typeof body.projectId === 'string' ? body.projectId.trim() : undefined;
+
+  if (!title || !content) {
+    return buildError('게시글 제목과 내용을 입력해주세요.');
+  }
+
+  let user;
+  try {
+    ({ user } = await requireUser());
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      return buildError(error.message, error.status);
+    }
+    throw error;
+  }
+
+  if (projectId) {
+    const project = await prisma.project.findUnique({ where: { id: projectId } });
+    if (!project) {
+      return buildError('연결된 프로젝트를 찾을 수 없습니다.', 404);
+    }
+  }
+
+  const post = await prisma.post.create({
+    data: {
+      title,
+      content,
+      projectId: projectId ?? null,
+      authorId: user.id
+    },
+    include: {
+      author: {
+        select: {
+          id: true,
+          name: true,
+          email: true
+        }
+      },
+      _count: {
+        select: {
+          likes: true,
+          comments: true
+        }
+      }
+    }
+  });
+
+  return NextResponse.json(mapPost(post), { status: 201 });
 }

--- a/app/api/partners/route.ts
+++ b/app/api/partners/route.ts
@@ -1,27 +1,45 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-const partners = [
-  {
-    id: 'studio-1',
-    name: 'Studio Aurora',
-    type: 'studio',
-    contactInfo: 'hello@aurora.studio',
-    status: 'approved'
-  },
-  {
-    id: 'venue-1',
-    name: 'Wonder Hall',
-    type: 'venue',
-    contactInfo: 'booking@wonderhall.kr',
-    status: 'review'
-  }
-];
+import prisma from '@/lib/prisma';
+
+function buildError(message: string, status = 400) {
+  return NextResponse.json({ error: message }, { status });
+}
 
 export async function GET() {
+  const partners = await prisma.partner.findMany({
+    orderBy: { createdAt: 'desc' }
+  });
+
   return NextResponse.json(partners);
 }
 
 export async function POST(request: NextRequest) {
-  const body = await request.json();
-  return NextResponse.json({ ...body, id: crypto.randomUUID(), status: 'review' }, { status: 201 });
+  let body: Record<string, unknown>;
+
+  try {
+    body = await request.json();
+  } catch {
+    return buildError('요청 본문을 확인할 수 없습니다.');
+  }
+
+  const name = typeof body.name === 'string' ? body.name.trim() : '';
+  const type = typeof body.type === 'string' ? body.type.trim() : '';
+  const contactInfo = typeof body.contactInfo === 'string' ? body.contactInfo.trim() : '';
+  const description = typeof body.description === 'string' ? body.description.trim() : undefined;
+
+  if (!name || !type || !contactInfo) {
+    return buildError('파트너 정보가 충분하지 않습니다.');
+  }
+
+  const partner = await prisma.partner.create({
+    data: {
+      name,
+      type,
+      contactInfo,
+      description: description ?? null
+    }
+  });
+
+  return NextResponse.json(partner, { status: 201 });
 }

--- a/app/api/projects/[id]/route.ts
+++ b/app/api/projects/[id]/route.ts
@@ -1,39 +1,198 @@
+import { Prisma } from '@prisma/client';
 import { NextRequest, NextResponse } from 'next/server';
 
-import { demoProjects } from '@/lib/data/projects';
+import prisma from '@/lib/prisma';
+import { AuthenticationError, requireUser } from '@/lib/auth/session';
+
+function buildError(message: string, status = 400) {
+  return NextResponse.json({ error: message }, { status });
+}
+
+function parseTargetAmount(value: unknown) {
+  if (typeof value === 'number') {
+    return Math.round(value);
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+
+  return Number.NaN;
+}
+
+function formatProject(project: {
+  _count: { fundings: number; settlements: number };
+  owner: { id: string; name: string | null; email: string };
+} & Record<string, unknown>) {
+  const { _count, ...projectData } = project;
+  return {
+    ...projectData,
+    metrics: {
+      fundings: _count.fundings,
+      settlements: _count.settlements
+    }
+  };
+}
+
+async function resolveProject(id: string) {
+  return prisma.project.findUnique({
+    where: { id },
+    include: {
+      owner: {
+        select: {
+          id: true,
+          name: true,
+          email: true
+        }
+      },
+      _count: {
+        select: {
+          fundings: true,
+          settlements: true
+        }
+      }
+    }
+  });
+}
 
 export async function GET(
   _request: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  const project = demoProjects.find((item) => item.id === params.id);
+  const project = await resolveProject(params.id);
   if (!project) {
-    return NextResponse.json({ message: 'Project not found' }, { status: 404 });
+    return buildError('해당 프로젝트를 찾을 수 없습니다.', 404);
   }
 
-  return NextResponse.json(project);
+  return NextResponse.json(formatProject(project));
 }
 
 export async function PATCH(
   request: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  const body = await request.json();
-  const project = demoProjects.find((item) => item.id === params.id);
-  if (!project) {
-    return NextResponse.json({ message: 'Project not found' }, { status: 404 });
+  let body: Record<string, unknown>;
+
+  try {
+    body = await request.json();
+  } catch {
+    return buildError('요청 본문을 확인할 수 없습니다.');
   }
 
-  return NextResponse.json({ ...project, ...body });
+  const project = await resolveProject(params.id);
+  if (!project) {
+    return buildError('해당 프로젝트를 찾을 수 없습니다.', 404);
+  }
+
+  let user;
+  try {
+    ({ user } = await requireUser());
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      return buildError(error.message, error.status);
+    }
+    throw error;
+  }
+
+  if (project.owner.id !== user.id) {
+    return buildError('프로젝트를 수정할 권한이 없습니다.', 403);
+  }
+
+  const data: Prisma.ProjectUpdateInput = {};
+
+  if (typeof body.title === 'string' && body.title.trim()) {
+    data.title = body.title.trim();
+  }
+
+  if (typeof body.description === 'string' && body.description.trim()) {
+    data.description = body.description.trim();
+  }
+
+  if (typeof body.category === 'string' && body.category.trim()) {
+    data.category = body.category.trim();
+  }
+
+  if (typeof body.status === 'string' && body.status.trim()) {
+    data.status = body.status.trim();
+  }
+
+  if (typeof body.thumbnail === 'string') {
+    const thumbnail = body.thumbnail.trim();
+    data.thumbnail = thumbnail.length > 0 ? thumbnail : null;
+  }
+
+  if (body.targetAmount !== undefined) {
+    const targetAmount = parseTargetAmount(body.targetAmount);
+    if (!Number.isFinite(targetAmount) || targetAmount <= 0) {
+      return buildError('목표 금액이 올바르지 않습니다.');
+    }
+    data.targetAmount = targetAmount;
+  }
+
+  if (Object.keys(data).length === 0) {
+    return buildError('변경할 항목을 확인할 수 없습니다.', 422);
+  }
+
+  const updated = await prisma.project.update({
+    where: { id: params.id },
+    data,
+    include: {
+      owner: {
+        select: {
+          id: true,
+          name: true,
+          email: true
+        }
+      },
+      _count: {
+        select: {
+          fundings: true,
+          settlements: true
+        }
+      }
+    }
+  });
+
+  return NextResponse.json(formatProject(updated));
 }
 
 export async function DELETE(
   _request: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  const project = demoProjects.find((item) => item.id === params.id);
+  const project = await resolveProject(params.id);
   if (!project) {
-    return NextResponse.json({ message: 'Project not found' }, { status: 404 });
+    return buildError('해당 프로젝트를 찾을 수 없습니다.', 404);
+  }
+
+  let user;
+  try {
+    ({ user } = await requireUser());
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      return buildError(error.message, error.status);
+    }
+    throw error;
+  }
+
+  if (project.owner.id !== user.id) {
+    return buildError('프로젝트를 삭제할 권한이 없습니다.', 403);
+  }
+
+  try {
+    await prisma.$transaction(async (tx) => {
+      await tx.funding.deleteMany({ where: { projectId: params.id } });
+      await tx.settlement.deleteMany({ where: { projectId: params.id } });
+      await tx.post.updateMany({ where: { projectId: params.id }, data: { projectId: null } });
+      await tx.project.delete({ where: { id: params.id } });
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : '프로젝트 삭제 중 오류가 발생했습니다.';
+    return buildError(message, 500);
   }
 
   return NextResponse.json({ message: 'Deleted' });

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -1,13 +1,128 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-import { demoProjects } from '@/lib/data/projects';
+import prisma from '@/lib/prisma';
+import { AuthenticationError, requireUser } from '@/lib/auth/session';
+
+function buildError(message: string, status = 400) {
+  return NextResponse.json({ error: message }, { status });
+}
+
+function parseTargetAmount(value: unknown) {
+  if (typeof value === 'number') {
+    return Math.round(value);
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+
+  return Number.NaN;
+}
 
 export async function GET() {
-  return NextResponse.json(demoProjects);
+  const projects = await prisma.project.findMany({
+    include: {
+      owner: {
+        select: {
+          id: true,
+          name: true,
+          email: true
+        }
+      },
+      _count: {
+        select: {
+          fundings: true,
+          settlements: true
+        }
+      }
+    },
+    orderBy: { createdAt: 'desc' }
+  });
+
+  const formatted = projects.map(({ _count, owner, ...project }) => ({
+    ...project,
+    owner,
+    metrics: {
+      fundings: _count.fundings,
+      settlements: _count.settlements
+    }
+  }));
+
+  return NextResponse.json(formatted);
 }
 
 export async function POST(request: NextRequest) {
-  const body = await request.json();
-  const project = { ...body, id: crypto.randomUUID() };
-  return NextResponse.json(project, { status: 201 });
+  let body: Record<string, unknown>;
+
+  try {
+    body = await request.json();
+  } catch {
+    return buildError('요청 본문을 확인할 수 없습니다.');
+  }
+
+  const title = typeof body.title === 'string' ? body.title.trim() : '';
+  const description = typeof body.description === 'string' ? body.description.trim() : '';
+  const category = typeof body.category === 'string' ? body.category.trim() : '';
+  const thumbnail = typeof body.thumbnail === 'string' ? body.thumbnail.trim() : undefined;
+  const targetAmount = parseTargetAmount(body.targetAmount);
+
+  if (!title || !description || !category) {
+    return buildError('프로젝트 정보가 충분하지 않습니다.');
+  }
+
+  if (!Number.isFinite(targetAmount) || targetAmount <= 0) {
+    return buildError('목표 금액이 올바르지 않습니다.');
+  }
+
+  let user;
+  try {
+    ({ user } = await requireUser());
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      return buildError(error.message, error.status);
+    }
+    throw error;
+  }
+
+  const project = await prisma.project.create({
+    data: {
+      title,
+      description,
+      category,
+      targetAmount,
+      thumbnail,
+      ownerId: user.id
+    },
+    include: {
+      owner: {
+        select: {
+          id: true,
+          name: true,
+          email: true
+        }
+      },
+      _count: {
+        select: {
+          fundings: true,
+          settlements: true
+        }
+      }
+    }
+  });
+
+  const { _count, ...projectData } = project;
+
+  return NextResponse.json(
+    {
+      ...projectData,
+      metrics: {
+        fundings: _count.fundings,
+        settlements: _count.settlements
+      }
+    },
+    { status: 201 }
+  );
 }

--- a/app/api/settlement/route.ts
+++ b/app/api/settlement/route.ts
@@ -2,6 +2,15 @@ import { NextRequest, NextResponse } from 'next/server';
 
 import prisma from '@/lib/prisma';
 
+class SettlementError extends Error {
+  status: number;
+
+  constructor(message: string, status = 400) {
+    super(message);
+    this.status = status;
+  }
+}
+
 function buildError(message: string, status = 400) {
   return NextResponse.json({ error: message }, { status });
 }
@@ -41,42 +50,113 @@ export async function POST(request: NextRequest) {
     return buildError('creatorRatio는 0과 1 사이의 숫자여야 합니다.');
   }
 
-  const project = await prisma.project.findUnique({ where: { id: projectId } });
-  if (!project) {
-    return buildError('해당 프로젝트를 찾을 수 없습니다.', 404);
-  }
+  try {
+    const result = await prisma.$transaction(async (tx) => {
+      const project = await tx.project.findUnique({ where: { id: projectId } });
+      if (!project) {
+        throw new SettlementError('해당 프로젝트를 찾을 수 없습니다.', 404);
+      }
 
-  const totals = await prisma.funding.aggregate({
-    where: { projectId },
-    _sum: { amount: true }
-  });
+      const totals = await tx.funding.aggregate({
+        where: { projectId },
+        _sum: { amount: true }
+      });
 
-  const totalAmount = totals._sum.amount ?? 0;
-  if (totalAmount < project.targetAmount) {
-    return buildError('목표 금액이 아직 달성되지 않았습니다.', 409);
-  }
+      const totalAmount = totals._sum.amount ?? 0;
+      if (totalAmount < project.targetAmount) {
+        throw new SettlementError('목표 금액이 아직 달성되지 않았습니다.', 409);
+      }
 
-  const pendingSettlement = await prisma.settlement.findFirst({
-    where: { projectId, distributed: false },
-    orderBy: { createdAt: 'desc' }
-  });
+      const pendingSettlement = await tx.settlement.findFirst({
+        where: { projectId, distributed: false },
+        orderBy: { createdAt: 'desc' }
+      });
 
-  if (pendingSettlement) {
-    return NextResponse.json(pendingSettlement);
-  }
+      if (pendingSettlement) {
+        return { settlement: pendingSettlement, created: false } as const;
+      }
 
-  const creatorShare = Math.round(totalAmount * creatorRatio);
-  const platformShare = totalAmount - creatorShare;
+      const creatorShare = Math.round(totalAmount * creatorRatio);
+      const platformShare = totalAmount - creatorShare;
 
-  const settlement = await prisma.settlement.create({
-    data: {
-      projectId,
-      totalAmount,
-      distributed: false,
-      creatorShare,
-      platformShare
+      const settlement = await tx.settlement.create({
+        data: {
+          projectId,
+          totalAmount,
+          distributed: false,
+          creatorShare,
+          platformShare
+        }
+      });
+
+      await tx.project.update({
+        where: { id: projectId },
+        data: { status: 'settlement_pending' }
+      });
+
+      return { settlement, created: true } as const;
+    });
+
+    return NextResponse.json(result.settlement, { status: result.created ? 201 : 200 });
+  } catch (error) {
+    if (error instanceof SettlementError) {
+      return buildError(error.message, error.status);
     }
-  });
 
-  return NextResponse.json(settlement, { status: 201 });
+    const message = error instanceof Error ? error.message : '정산 처리 중 오류가 발생했습니다.';
+    return buildError(message, 500);
+  }
+}
+
+export async function PATCH(request: NextRequest) {
+  let body: Record<string, unknown>;
+
+  try {
+    body = await request.json();
+  } catch {
+    return buildError('요청 본문을 확인할 수 없습니다.');
+  }
+
+  const settlementId = typeof body.settlementId === 'string' ? body.settlementId.trim() : '';
+  const distributed = body.distributed === undefined ? true : Boolean(body.distributed);
+
+  if (!settlementId) {
+    return buildError('정산 정보를 확인할 수 없습니다.');
+  }
+
+  try {
+    const updated = await prisma.$transaction(async (tx) => {
+      const settlement = await tx.settlement.findUnique({ where: { id: settlementId } });
+      if (!settlement) {
+        throw new SettlementError('정산 내역을 찾을 수 없습니다.', 404);
+      }
+
+      if (settlement.distributed === distributed) {
+        return settlement;
+      }
+
+      const nextStatus = distributed ? 'settled' : 'settlement_pending';
+
+      const result = await tx.settlement.update({
+        where: { id: settlementId },
+        data: { distributed }
+      });
+
+      await tx.project.update({
+        where: { id: settlement.projectId },
+        data: { status: nextStatus }
+      });
+
+      return result;
+    });
+
+    return NextResponse.json(updated);
+  } catch (error) {
+    if (error instanceof SettlementError) {
+      return buildError(error.message, error.status);
+    }
+
+    const message = error instanceof Error ? error.message : '정산 업데이트 중 오류가 발생했습니다.';
+    return buildError(message, 500);
+  }
 }

--- a/lib/auth/session.ts
+++ b/lib/auth/session.ts
@@ -1,0 +1,58 @@
+import { Prisma } from '@prisma/client';
+import { getServerSession } from 'next-auth';
+
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import prisma from '@/lib/prisma';
+
+export class AuthenticationError extends Error {
+  status: number;
+
+  constructor(message = '로그인이 필요합니다.', status = 401) {
+    super(message);
+    this.status = status;
+  }
+}
+
+function buildUserName(email: string, fallback?: string | null) {
+  if (fallback && fallback.trim().length > 0) {
+    return fallback.trim();
+  }
+
+  const [localPart] = email.split('@');
+  if (localPart && localPart.trim().length > 0) {
+    return localPart.trim();
+  }
+
+  return 'User';
+}
+
+export async function requireUser() {
+  const session = await getServerSession(authOptions);
+
+  const email = session?.user?.email?.toLowerCase();
+  if (!email) {
+    throw new AuthenticationError();
+  }
+
+  const name = buildUserName(email, session.user?.name);
+
+  const updateData: Prisma.UserUpdateInput = {
+    name
+  };
+
+  if (session.user?.role) {
+    updateData.role = session.user.role;
+  }
+
+  const user = await prisma.user.upsert({
+    where: { email },
+    update: updateData,
+    create: {
+      email,
+      name,
+      role: session.user?.role ?? 'fan'
+    }
+  });
+
+  return { user, session };
+}


### PR DESCRIPTION
## Summary
- export reusable NextAuth options and add a Prisma-backed helper to hydrate authenticated users
- replace projects and community API handlers with Prisma CRUD plus owner/session enforcement
- persist partner onboarding and settlement workflows to the database with transactional safety

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d5fea62dc48326aa00dbc8fe58ace5