### PR TITLE
Integrate Prisma-backed authentication and role guard

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+import { withAuth } from 'next-auth/middleware';
+import type { NextRequestWithAuth } from 'next-auth/middleware';
+
+interface RoleGuard {
+  matcher: string;
+  pattern: RegExp;
+  roles: string[];
+}
+
+const ROLE_GUARDS: RoleGuard[] = [
+  {
+    matcher: '/admin/:path*',
+    pattern: /^\/admin(?:\/.*)?$/,
+    roles: ['admin']
+  }
+];
+
+export default withAuth(
+  function middleware(req: NextRequestWithAuth) {
+    const guard = ROLE_GUARDS.find(({ pattern }) => pattern.test(req.nextUrl.pathname));
+
+    if (!guard) {
+      return NextResponse.next();
+    }
+
+    const token = req.nextauth.token;
+
+    if (!token || !token.role || !guard.roles.includes(token.role)) {
+      const signInUrl = new URL('/api/auth/signin', req.url);
+      signInUrl.searchParams.set('error', 'AccessDenied');
+      return NextResponse.redirect(signInUrl);
+    }
+
+    return NextResponse.next();
+  },
+  {
+    callbacks: {
+      authorized: ({ token }) => Boolean(token)
+    }
+  }
+);
+
+export const config = {
+  matcher: ROLE_GUARDS.map((guard) => guard.matcher)
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@tanstack/react-query": "^5.56.1",
         "autoprefixer": "^10.4.20",
         "axios": "^1.7.8",
+        "bcryptjs": "^3.0.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "embla-carousel-autoplay": "^8.1.6",
@@ -4971,6 +4972,15 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
+      "integrity": "sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
       }
     },
     "node_modules/binary-extensions": {

--- a/package.json
+++ b/package.json
@@ -40,8 +40,10 @@
     "@tanstack/react-query": "^5.56.1",
     "autoprefixer": "^10.4.20",
     "axios": "^1.7.8",
+    "bcryptjs": "^3.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "embla-carousel-autoplay": "^8.1.6",
     "embla-carousel-react": "^8.6.0",
     "i18next": "^25.1.0",
     "lucide-react": "^0.487.0",
@@ -61,8 +63,7 @@
     "swiper": "^11.1.3",
     "tailwind-merge": "^2.2.1",
     "tailwindcss": "^3.4.14",
-    "zustand": "^5.0.0",
-    "embla-carousel-autoplay": "^8.1.6"
+    "zustand": "^5.0.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.5.0",

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -4,6 +4,7 @@ import { JWT } from 'next-auth/jwt';
 declare module 'next-auth' {
   interface Session {
     user?: {
+      id?: string;
       name?: string | null;
       email?: string | null;
       role?: string;


### PR DESCRIPTION
## Summary
- connect the NextAuth instance to the Prisma adapter and validate credential sign-ins against stored user records
- enforce Google and Kakao OAuth configuration at build time while synchronizing user roles in JWT and session callbacks
- add a role-based middleware scaffold and the bcryptjs dependency for secure password comparison

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d5feaae1a483269add3da1f4c412b9