### PR TITLE
Integrate Prisma-backed authentication and role guard

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,9 +1,58 @@
+import { timingSafeEqual } from 'crypto';
+
 import NextAuth from 'next-auth';
+import type { NextAuthOptions } from 'next-auth';
 import CredentialsProvider from 'next-auth/providers/credentials';
 import GoogleProvider from 'next-auth/providers/google';
 import KakaoProvider from 'next-auth/providers/kakao';
+import { PrismaAdapter } from '@next-auth/prisma-adapter';
+import { compare } from 'bcryptjs';
 
-const handler = NextAuth({
+import prisma from '@/lib/prisma';
+
+const DEFAULT_ROLE = 'fan' as const;
+
+type SupportedRole = typeof DEFAULT_ROLE | string;
+
+const requiredOAuthEnvVars = [
+  { key: 'GOOGLE_CLIENT_ID', provider: 'Google' },
+  { key: 'GOOGLE_CLIENT_SECRET', provider: 'Google' },
+  { key: 'KAKAO_CLIENT_ID', provider: 'Kakao' },
+  { key: 'KAKAO_CLIENT_SECRET', provider: 'Kakao' }
+] as const;
+
+const readRequiredEnv = (key: string, provider: string) => {
+  const value = process.env[key];
+
+  if (!value) {
+    throw new Error(
+      `${provider} OAuth configuration is missing the required environment variable "${key}".`
+    );
+  }
+
+  return value;
+};
+
+const oauthSecrets = requiredOAuthEnvVars.reduce(
+  (acc, { key, provider }) => ({
+    ...acc,
+    [key]: readRequiredEnv(key, provider)
+  }),
+  {} as Record<(typeof requiredOAuthEnvVars)[number]['key'], string>
+);
+
+const safeCompare = (a: string, b: string) => {
+  const bufferA = Buffer.from(a);
+  const bufferB = Buffer.from(b);
+
+  if (bufferA.length !== bufferB.length) {
+    return false;
+  }
+
+  return timingSafeEqual(bufferA, bufferB);
+};
+export const authOptions: NextAuthOptions = {
+  adapter: PrismaAdapter(prisma),
   session: {
     strategy: 'jwt'
   },
@@ -19,37 +68,100 @@ const handler = NextAuth({
           return null;
         }
 
+        const email = credentials.email.trim();
+
+        if (!email || !credentials.password.trim()) {
+          return null;
+        }
+
+        const user = await prisma.user.findUnique({
+          where: {
+            email
+          },
+          select: {
+            id: true,
+            email: true,
+            name: true,
+            password: true,
+            role: true
+          }
+        });
+
+        if (!user || !user.password) {
+          return null;
+        }
+
+        let passwordMatches = false;
+
+        try {
+          if (user.password.startsWith('$2')) {
+            passwordMatches = await compare(credentials.password, user.password);
+          } else {
+            passwordMatches = safeCompare(user.password, credentials.password);
+          }
+        } catch {
+          passwordMatches = false;
+        }
+
+        if (!passwordMatches) {
+          return null;
+        }
+
         return {
-          id: 'demo-user',
-          name: 'Collabo Fan',
-          email: credentials.email,
-          role: 'fan'
+          id: user.id,
+          name: user.name,
+          email: user.email,
+          role: (user.role ?? DEFAULT_ROLE) as SupportedRole
         };
       }
     }),
     GoogleProvider({
-      clientId: process.env.GOOGLE_CLIENT_ID ?? 'placeholder',
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? 'placeholder'
+      clientId: oauthSecrets.GOOGLE_CLIENT_ID,
+      clientSecret: oauthSecrets.GOOGLE_CLIENT_SECRET
     }),
     KakaoProvider({
-      clientId: process.env.KAKAO_CLIENT_ID ?? 'placeholder',
-      clientSecret: process.env.KAKAO_CLIENT_SECRET ?? 'placeholder'
+      clientId: oauthSecrets.KAKAO_CLIENT_ID,
+      clientSecret: oauthSecrets.KAKAO_CLIENT_SECRET
     })
   ],
   callbacks: {
     async session({ session, token }) {
       if (session.user) {
-        session.user.role = (token.role as string) ?? 'fan';
+        if (token.sub) {
+          session.user.id = token.sub;
+        }
+        const resolvedRole =
+          (token.role as SupportedRole | undefined) ??
+          (session.user.role as SupportedRole | undefined) ??
+          DEFAULT_ROLE;
+
+        session.user.role = resolvedRole;
       }
+
       return session;
     },
-    async jwt({ token }) {
-      if (!token.role) {
-        token.role = 'fan';
+    async jwt({ token, user, trigger }) {
+      if (user) {
+        token.role = user.role;
       }
+
+      const shouldSyncRole = Boolean(token.email && (!token.role || trigger === 'update'));
+
+      if (shouldSyncRole) {
+        const dbUser = await prisma.user.findUnique({
+          where: { email: token.email as string }
+        });
+
+        if (dbUser) {
+          token.role = dbUser.role;
+        }
+      }
+
       return token;
     }
   }
-});
+};
+
+const handler = NextAuth(authOptions);
 
 export { handler as GET, handler as POST };

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+import { withAuth } from 'next-auth/middleware';
+import type { NextRequestWithAuth } from 'next-auth/middleware';
+
+interface RoleGuard {
+  matcher: string;
+  pattern: RegExp;
+  roles: string[];
+}
+
+const ROLE_GUARDS: RoleGuard[] = [
+  {
+    matcher: '/admin/:path*',
+    pattern: /^\/admin(?:\/.*)?$/,
+    roles: ['admin']
+  }
+];
+
+export default withAuth(
+  function middleware(req: NextRequestWithAuth) {
+    const guard = ROLE_GUARDS.find(({ pattern }) => pattern.test(req.nextUrl.pathname));
+
+    if (!guard) {
+      return NextResponse.next();
+    }
+
+    const token = req.nextauth.token;
+
+    if (!token || !token.role || !guard.roles.includes(token.role)) {
+      const signInUrl = new URL('/api/auth/signin', req.url);
+      signInUrl.searchParams.set('error', 'AccessDenied');
+      return NextResponse.redirect(signInUrl);
+    }
+
+    return NextResponse.next();
+  },
+  {
+    callbacks: {
+      authorized: ({ token }) => Boolean(token)
+    }
+  }
+);
+
+export const config = {
+  matcher: ROLE_GUARDS.map((guard) => guard.matcher)
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@tanstack/react-query": "^5.56.1",
         "autoprefixer": "^10.4.20",
         "axios": "^1.7.8",
+        "bcryptjs": "^3.0.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "embla-carousel-autoplay": "^8.1.6",
@@ -4971,6 +4972,15 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
+      "integrity": "sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
       }
     },
     "node_modules/binary-extensions": {

--- a/package.json
+++ b/package.json
@@ -40,8 +40,10 @@
     "@tanstack/react-query": "^5.56.1",
     "autoprefixer": "^10.4.20",
     "axios": "^1.7.8",
+    "bcryptjs": "^3.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "embla-carousel-autoplay": "^8.1.6",
     "embla-carousel-react": "^8.6.0",
     "i18next": "^25.1.0",
     "lucide-react": "^0.487.0",
@@ -61,8 +63,7 @@
     "swiper": "^11.1.3",
     "tailwind-merge": "^2.2.1",
     "tailwindcss": "^3.4.14",
-    "zustand": "^5.0.0",
-    "embla-carousel-autoplay": "^8.1.6"
+    "zustand": "^5.0.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.5.0",

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -4,6 +4,7 @@ import { JWT } from 'next-auth/jwt';
 declare module 'next-auth' {
   interface Session {
     user?: {
+      id?: string;
       name?: string | null;
       email?: string | null;
       role?: string;


### PR DESCRIPTION
## Summary
- connect the NextAuth instance to the Prisma adapter, sanitize credential input, and validate sign-ins against stored user records
- enforce Google and Kakao OAuth configuration at build time while synchronizing user roles in JWT and session callbacks
- add a role-based middleware scaffold and the bcryptjs dependency for secure password comparison

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d5feaae1a483269add3da1f4c412b9