### PR TITLE
Fix TypeScript configuration for React typings

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,9 @@
     },
     "types": [
       "jest",
-      "node"
+      "node",
+      "react",
+      "react-dom"
     ],
     "plugins": [
       {


### PR DESCRIPTION
## Summary
- include React and React DOM type definitions in the TypeScript configuration so JSX elements resolve correctly

## Testing
- npx tsc --noEmit *(fails: existing Prisma- and domain-level typing errors)*

------
https://chatgpt.com/codex/tasks/task_b_68d7869184188326a76553bc640629ce