### PR TITLE
Require authentication for funding flow

### DIFF
--- a/__tests__/api/funding-route.test.ts
+++ b/__tests__/api/funding-route.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, beforeEach } from '@jest/globals';
+import { NextRequest } from 'next/server';
+
+import { POST } from '@/app/api/funding/route';
+import { AuthorizationError, requireApiUser } from '@/lib/auth/guards';
+
+jest.mock('@/lib/auth/guards', () => {
+  const actual = jest.requireActual('@/lib/auth/guards');
+  return {
+    ...actual,
+    requireApiUser: jest.fn()
+  };
+});
+
+describe('Funding API authentication', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 401 when session is not authenticated', async () => {
+    const mockRequireApiUser = requireApiUser as jest.MockedFunction<typeof requireApiUser>;
+    mockRequireApiUser.mockRejectedValueOnce(new AuthorizationError('인증이 필요합니다.', 401));
+
+    const request = new NextRequest('http://localhost:3000/api/funding', {
+      method: 'POST',
+      body: JSON.stringify({ projectId: 'test-project' })
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(401);
+
+    const json = await response.json();
+    expect(json.error).toBe('인증이 필요합니다.');
+
+    expect(mockRequireApiUser).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/funding-dialog.test.tsx
+++ b/tests/funding-dialog.test.tsx
@@ -1,0 +1,97 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import { FundingDialog } from '@/components/ui/dialogs/funding-dialog';
+import { signIn, useSession } from 'next-auth/react';
+
+jest.mock('next-auth/react', () => ({
+  useSession: jest.fn(),
+  signIn: jest.fn()
+}));
+
+jest.mock('@stripe/stripe-js', () => ({
+  loadStripe: jest.fn().mockResolvedValue({})
+}));
+
+jest.mock('@stripe/react-stripe-js', () => ({
+  Elements: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  PaymentElement: () => <div data-testid="payment-element" />,
+  useStripe: () => null,
+  useElements: () => ({})
+}));
+
+describe('FundingDialog', () => {
+  const originalLocation = window.location;
+  const mockUseSession = useSession as jest.MockedFunction<typeof useSession>;
+  const mockSignIn = signIn as jest.MockedFunction<typeof signIn>;
+
+  beforeAll(() => {
+    delete (window as unknown as { location?: Location }).location;
+    (window as unknown as { location: { href: string } }).location = { href: 'http://localhost/test' };
+  });
+
+  afterAll(() => {
+    window.location = originalLocation;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = 'pk_test_123';
+  });
+
+  it('prompts users to sign in when unauthenticated', () => {
+    mockUseSession.mockReturnValue({ data: null, status: 'unauthenticated' } as any);
+
+    render(
+      <FundingDialog projectId="project-1" projectTitle="프로젝트" />
+    );
+
+    const button = screen.getByRole('button', { name: '로그인 후 후원하기' });
+    fireEvent.click(button);
+
+    expect(mockSignIn).toHaveBeenCalledWith(undefined, { callbackUrl: 'http://localhost/test' });
+  });
+
+  it('prefills session data and surfaces auth guidance on 401', async () => {
+    mockUseSession.mockReturnValue({
+      data: { user: { id: 'user-1', email: 'user@example.com', name: 'Test User' } },
+      status: 'authenticated'
+    } as any);
+
+    const originalFetch = global.fetch;
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({ error: '인증이 필요합니다.' })
+    } as any);
+    // @ts-expect-error - override fetch for test scenario
+    global.fetch = fetchMock;
+
+    try {
+      render(
+        <FundingDialog projectId="project-1" projectTitle="프로젝트" />
+      );
+
+      const trigger = screen.getByRole('button', { name: '후원하기' });
+      fireEvent.click(trigger);
+
+      const emailInput = await screen.findByLabelText('영수증 이메일');
+      expect((emailInput as HTMLInputElement).value).toBe('user@example.com');
+
+      const submitButton = screen.getByRole('button', { name: /결제하기/ });
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('후원을 진행하려면 로그인이 필요합니다.')).toBeInTheDocument();
+      });
+
+      const signInButton = screen.getByRole('button', { name: '로그인하러 가기' });
+      fireEvent.click(signInButton);
+      expect(mockSignIn).toHaveBeenLastCalledWith(undefined, { callbackUrl: 'http://localhost/test' });
+
+      expect(fetchMock).toHaveBeenCalled();
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- gate the funding API behind authenticated sessions, reusing the logged-in user for Stripe metadata
- update the funding dialog to prefill session details and redirect guests toward sign-in when necessary
- add API and UI tests covering the new authentication requirements and guest guidance

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d7e22e92748326b34d24a59a32d7e9