### PR TITLE
Add admin dashboard and centralize role guard usage

### DIFF
--- a/app/admin/_components/moderation-report-section.tsx
+++ b/app/admin/_components/moderation-report-section.tsx
@@ -1,0 +1,70 @@
+import { ModerationStatus, ModerationTargetType } from '@/types/prisma';
+
+import { getOpenModerationReports } from '@/lib/server/moderation';
+
+const statusLabels: Record<ModerationStatus, string> = {
+  [ModerationStatus.PENDING]: '신고 접수',
+  [ModerationStatus.REVIEWING]: '검토 중',
+  [ModerationStatus.ACTION_TAKEN]: '조치 완료',
+  [ModerationStatus.DISMISSED]: '기각'
+};
+
+const targetLabels: Record<ModerationTargetType, string> = {
+  [ModerationTargetType.POST]: '게시물',
+  [ModerationTargetType.COMMENT]: '댓글'
+};
+
+const dateFormatter = new Intl.DateTimeFormat('ko-KR', {
+  dateStyle: 'medium',
+  timeStyle: 'short'
+});
+
+export async function ModerationReportSection() {
+  const reports = await getOpenModerationReports();
+
+  return (
+    <section
+      id="moderation"
+      className="rounded-3xl border border-white/10 bg-white/[0.03] p-6 shadow-lg shadow-black/5"
+    >
+      <header>
+        <p className="text-xs uppercase tracking-wider text-primary/60">신고 대응</p>
+        <h2 className="mt-1 text-lg font-semibold text-white">처리 대기 신고</h2>
+        <p className="mt-2 text-sm text-white/60">
+          커뮤니티의 신뢰를 유지하기 위해 신고된 콘텐츠를 빠르게 확인하세요.
+        </p>
+      </header>
+
+      {reports.length > 0 ? (
+        <ul className="mt-6 space-y-3">
+          {reports.map((report) => (
+            <li
+              key={report.id}
+              className="flex items-start justify-between rounded-2xl border border-white/5 bg-white/[0.05] px-4 py-3"
+            >
+              <div className="pr-4">
+                <p className="text-sm font-medium text-white">
+                  {targetLabels[report.targetType]} #{report.targetId}
+                </p>
+                <p className="mt-1 text-xs text-white/60">
+                  접수 {dateFormatter.format(report.createdAt)}
+                  {report.reporter ? ` · 신고자 ${report.reporter.name ?? report.reporter.id}` : ''}
+                </p>
+                {report.reason ? (
+                  <p className="mt-2 line-clamp-2 text-xs text-white/70">{report.reason}</p>
+                ) : null}
+              </div>
+              <span className="shrink-0 rounded-full border border-white/20 px-3 py-1 text-xs font-semibold text-white/80">
+                {statusLabels[report.status]}
+              </span>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="mt-6 rounded-2xl border border-dashed border-white/10 bg-white/5 px-4 py-6 text-center text-sm text-white/60">
+          대응이 필요한 신고가 없습니다.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/app/admin/_components/partner-approval-section.tsx
+++ b/app/admin/_components/partner-approval-section.tsx
@@ -1,0 +1,57 @@
+import { PartnerType } from '@/types/prisma';
+
+import { getPartnersAwaitingApproval } from '@/lib/server/partners';
+
+const partnerTypeLabels: Record<PartnerType, string> = {
+  [PartnerType.STUDIO]: '스튜디오',
+  [PartnerType.VENUE]: '공연장',
+  [PartnerType.PRODUCTION]: '프로덕션',
+  [PartnerType.MERCHANDISE]: '머천다이즈',
+  [PartnerType.OTHER]: '기타'
+};
+
+const dateFormatter = new Intl.DateTimeFormat('ko-KR', { dateStyle: 'medium' });
+
+export async function PartnerApprovalSection() {
+  const partners = await getPartnersAwaitingApproval();
+
+  return (
+    <section
+      id="partner-approvals"
+      className="rounded-3xl border border-white/10 bg-white/[0.03] p-6 shadow-lg shadow-black/5"
+    >
+      <header>
+        <p className="text-xs uppercase tracking-wider text-primary/60">파트너 승인</p>
+        <h2 className="mt-1 text-lg font-semibold text-white">검토 대기 파트너</h2>
+        <p className="mt-2 text-sm text-white/60">
+          인증되지 않은 파트너 프로필을 빠르게 확인하고 승인 상태를 업데이트하세요.
+        </p>
+      </header>
+
+      {partners.length > 0 ? (
+        <ul className="mt-6 space-y-3">
+          {partners.map((partner) => (
+            <li
+              key={partner.id}
+              className="flex items-center justify-between rounded-2xl border border-white/5 bg-white/[0.05] px-4 py-3"
+            >
+              <div>
+                <p className="text-sm font-medium text-white">{partner.name}</p>
+                <p className="text-xs text-white/50">
+                  {partnerTypeLabels[partner.type]} · 등록일 {dateFormatter.format(partner.createdAt)}
+                </p>
+              </div>
+              <span className="rounded-full border border-white/20 px-3 py-1 text-xs font-semibold text-white/80">
+                미승인
+              </span>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="mt-6 rounded-2xl border border-dashed border-white/10 bg-white/5 px-4 py-6 text-center text-sm text-white/60">
+          승인 대기 중인 파트너가 없습니다.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/app/admin/_components/project-review-section.tsx
+++ b/app/admin/_components/project-review-section.tsx
@@ -1,0 +1,52 @@
+import { PROJECT_STATUS_LABELS } from '@/types/prisma';
+
+import { getProjectsPendingReview } from '@/lib/server/projects';
+
+const dateFormatter = new Intl.DateTimeFormat('ko-KR', {
+  dateStyle: 'medium',
+  timeStyle: 'short'
+});
+
+export async function ProjectReviewSection() {
+  const projects = await getProjectsPendingReview();
+
+  return (
+    <section
+      id="project-review"
+      className="rounded-3xl border border-white/10 bg-white/[0.03] p-6 shadow-lg shadow-black/5"
+    >
+      <header>
+        <p className="text-xs uppercase tracking-wider text-primary/60">프로젝트 검수</p>
+        <h2 className="mt-1 text-lg font-semibold text-white">검토 대기 프로젝트</h2>
+        <p className="mt-2 text-sm text-white/60">
+          업로드된 프로젝트 중 검토 상태(REVIEWING)에 머무르고 있는 항목입니다.
+        </p>
+      </header>
+
+      {projects.length > 0 ? (
+        <ul className="mt-6 space-y-3">
+          {projects.map((project) => (
+            <li
+              key={project.id}
+              className="flex items-center justify-between rounded-2xl border border-white/5 bg-white/[0.05] px-4 py-3"
+            >
+              <div>
+                <p className="text-sm font-medium text-white">{project.title}</p>
+                <p className="text-xs text-white/50">
+                  신청일 {dateFormatter.format(project.createdAt)} · 참여 {project.participants}명
+                </p>
+              </div>
+              <span className="text-xs font-semibold text-amber-300">
+                {PROJECT_STATUS_LABELS[project.status]}
+              </span>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="mt-6 rounded-2xl border border-dashed border-white/10 bg-white/5 px-4 py-6 text-center text-sm text-white/60">
+          검토 대기 중인 프로젝트가 없습니다.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/app/admin/_components/settlement-queue-section.tsx
+++ b/app/admin/_components/settlement-queue-section.tsx
@@ -1,0 +1,62 @@
+import { SettlementPayoutStatus } from '@/types/prisma';
+
+import { getSettlementsPendingPayout } from '@/lib/server/settlement-queries';
+
+const statusLabels: Record<SettlementPayoutStatus, string> = {
+  [SettlementPayoutStatus.PENDING]: '정산 준비',
+  [SettlementPayoutStatus.IN_PROGRESS]: '정산 진행 중',
+  [SettlementPayoutStatus.PAID]: '정산 완료'
+};
+
+const currencyFormatter = new Intl.NumberFormat('ko-KR', {
+  style: 'currency',
+  currency: 'KRW',
+  maximumFractionDigits: 0
+});
+
+const dateFormatter = new Intl.DateTimeFormat('ko-KR', { dateStyle: 'medium' });
+
+export async function SettlementQueueSection() {
+  const settlements = await getSettlementsPendingPayout();
+
+  return (
+    <section
+      id="settlements"
+      className="rounded-3xl border border-white/10 bg-white/[0.03] p-6 shadow-lg shadow-black/5"
+    >
+      <header>
+        <p className="text-xs uppercase tracking-wider text-primary/60">정산 관리</p>
+        <h2 className="mt-1 text-lg font-semibold text-white">정산 대기 목록</h2>
+        <p className="mt-2 text-sm text-white/60">
+          펀딩 성공 이후 정산 상태를 모니터링하고 지급 일정을 조율하세요.
+        </p>
+      </header>
+
+      {settlements.length > 0 ? (
+        <ul className="mt-6 space-y-3">
+          {settlements.map((settlement) => (
+            <li
+              key={settlement.id}
+              className="flex items-center justify-between rounded-2xl border border-white/5 bg-white/[0.05] px-4 py-3"
+            >
+              <div>
+                <p className="text-sm font-medium text-white">{settlement.projectTitle}</p>
+                <p className="text-xs text-white/50">
+                  총 모금액 {currencyFormatter.format(settlement.totalRaised)} · 업데이트{' '}
+                  {dateFormatter.format(settlement.updatedAt)}
+                </p>
+              </div>
+              <span className="rounded-full border border-white/20 px-3 py-1 text-xs font-semibold text-white/80">
+                {statusLabels[settlement.payoutStatus]}
+              </span>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="mt-6 rounded-2xl border border-dashed border-white/10 bg-white/5 px-4 py-6 text-center text-sm text-white/60">
+          진행 중인 정산 건이 없습니다.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,0 +1,43 @@
+import type { ReactNode } from 'react';
+
+import { requireUser } from '@/lib/auth/guards';
+import { ROLE_LABELS, UserRole } from '@/types/prisma';
+
+const navigationAnchors = [
+  { href: '#project-review', label: '프로젝트 검수' },
+  { href: '#partner-approvals', label: '파트너 승인' },
+  { href: '#moderation', label: '신고 대응' },
+  { href: '#settlements', label: '정산 관리' }
+];
+
+export default async function AdminLayout({ children }: { children: ReactNode }) {
+  const { user } = await requireUser({
+    roles: [UserRole.ADMIN],
+    redirectTo: '/admin'
+  });
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 pb-24">
+      <header className="pb-6 pt-12">
+        <p className="text-xs uppercase tracking-[0.2em] text-primary/60">Admin</p>
+        <h1 className="mt-2 text-3xl font-semibold text-white">관리 센터</h1>
+        <p className="mt-3 text-sm text-white/60">
+          {user.name ? `${user.name}님, ` : ''}
+          {ROLE_LABELS[user.role]} 역할로 플랫폼의 품질과 안정성을 관리할 수 있습니다.
+        </p>
+        <nav className="mt-6 flex flex-wrap gap-3">
+          {navigationAnchors.map((item) => (
+            <a
+              key={item.href}
+              href={item.href}
+              className="rounded-full border border-white/10 bg-white/[0.04] px-4 py-2 text-xs font-medium text-white/80 transition hover:border-white/30 hover:bg-white/[0.08] hover:text-white"
+            >
+              {item.label}
+            </a>
+          ))}
+        </nav>
+      </header>
+      <div className="space-y-10 pb-8">{children}</div>
+    </div>
+  );
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,15 @@
+import { ModerationReportSection } from './_components/moderation-report-section';
+import { PartnerApprovalSection } from './_components/partner-approval-section';
+import { ProjectReviewSection } from './_components/project-review-section';
+import { SettlementQueueSection } from './_components/settlement-queue-section';
+
+export default function AdminDashboardPage() {
+  return (
+    <div className="space-y-10">
+      <ProjectReviewSection />
+      <PartnerApprovalSection />
+      <ModerationReportSection />
+      <SettlementQueueSection />
+    </div>
+  );
+}

--- a/components/ui/layout/header.tsx
+++ b/components/ui/layout/header.tsx
@@ -3,8 +3,20 @@
 import Link from 'next/link';
 import { useSession } from 'next-auth/react';
 
+import { canAccessRoute } from '@/lib/auth/role-guards';
+
 export function Header() {
   const { data: session } = useSession();
+
+  const navigationItems = [
+    { href: '/projects', label: '프로젝트' },
+    { href: '/partners', label: '파트너' },
+    { href: '/community', label: '커뮤니티' }
+  ];
+
+  if (session?.user && canAccessRoute(session.user, '/admin')) {
+    navigationItems.push({ href: '/admin', label: '관리' });
+  }
 
   return (
     <header className="bg-neutral-900 border-b border-neutral-800 sticky top-0 z-50">
@@ -13,17 +25,13 @@ export function Header() {
           <Link href="/" className="text-xl font-bold">
             Collaborium
           </Link>
-          
+
           <nav className="hidden md:flex items-center space-x-8">
-            <Link href="/projects" className="hover:text-neutral-300 transition-colors">
-              프로젝트
-            </Link>
-            <Link href="/partners" className="hover:text-neutral-300 transition-colors">
-              파트너
-            </Link>
-            <Link href="/community" className="hover:text-neutral-300 transition-colors">
-              커뮤니티
-            </Link>
+            {navigationItems.map((item) => (
+              <Link key={item.href} href={item.href} className="hover:text-neutral-300 transition-colors">
+                {item.label}
+              </Link>
+            ))}
           </nav>
 
           <div className="flex items-center space-x-4">

--- a/components/ui/layout/mobile-tab-bar.tsx
+++ b/components/ui/layout/mobile-tab-bar.tsx
@@ -2,39 +2,52 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { useSession } from 'next-auth/react';
 
-const tabs = [
-    { href: '/', label: '홈', icon: '🏠' },
-    { href: '/projects', label: '프로젝트', icon: '🎵' },
-    { href: '/partners', label: '파트너', icon: '🤝' },
-    { href: '/community', label: '커뮤니티', icon: '💬' },
+import { canAccessRoute } from '@/lib/auth/role-guards';
+
+const baseTabs = [
+  { href: '/', label: '홈', icon: '🏠' },
+  { href: '/projects', label: '프로젝트', icon: '🎵' },
+  { href: '/partners', label: '파트너', icon: '🤝' },
+  { href: '/community', label: '커뮤니티', icon: '💬' }
 ];
 
 export function MobileTabBar() {
-    const pathname = usePathname();
+  const pathname = usePathname();
+  const { data: session } = useSession();
 
-    return (
-        <div className="fixed bottom-0 left-0 right-0 bg-neutral-900 border-t border-neutral-800 md:hidden z-50">
-            <div className="grid grid-cols-4 h-16">
-                {tabs.map((tab) => {
-                    const isActive = pathname === tab.href ||
-                        (tab.href !== '/' && pathname.startsWith(tab.href));
+  const tabs = [...baseTabs];
 
-                    return (
-                        <Link
-                            key={tab.href}
-                            href={tab.href}
-                            className={`flex flex-col items-center justify-center space-y-1 ${isActive
-                                    ? 'text-blue-400'
-                                    : 'text-neutral-400 hover:text-neutral-300'
-                                } transition-colors`}
-                        >
-                            <span className="text-lg">{tab.icon}</span>
-                            <span className="text-xs font-medium">{tab.label}</span>
-                        </Link>
-                    );
-                })}
-            </div>
-        </div>
-    );
+  if (session?.user && canAccessRoute(session.user, '/admin')) {
+    tabs.push({ href: '/admin', label: '관리', icon: '🛠️' });
+  }
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 bg-neutral-900 border-t border-neutral-800 md:hidden z-50">
+      <div
+        className="grid h-16"
+        style={{ gridTemplateColumns: `repeat(${tabs.length}, minmax(0, 1fr))` }}
+      >
+        {tabs.map((tab) => {
+          const isActive =
+            pathname === tab.href || (tab.href !== '/' && pathname.startsWith(tab.href));
+
+          return (
+            <Link
+              key={tab.href}
+              href={tab.href}
+              className={[
+                'flex flex-col items-center justify-center space-y-1 transition-colors',
+                isActive ? 'text-blue-400' : 'text-neutral-400 hover:text-neutral-300'
+              ].join(' ')}
+            >
+              <span className="text-lg">{tab.icon}</span>
+              <span className="text-xs font-medium">{tab.label}</span>
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
 }

--- a/lib/auth/role-guards.ts
+++ b/lib/auth/role-guards.ts
@@ -1,0 +1,80 @@
+import { UserRole } from '@/types/prisma';
+
+import { hasAllPermissions, normalizeRole } from './permissions';
+
+export interface RoleGuard {
+  matcher: string;
+  pattern: RegExp;
+  roles?: UserRole[];
+  permissions?: string[];
+}
+
+export const ROLE_GUARDS: RoleGuard[] = [
+  {
+    matcher: '/admin/:path*',
+    pattern: /^\/admin(?:\/.*)?$/,
+    roles: [UserRole.ADMIN]
+  },
+  {
+    matcher: '/projects/new',
+    pattern: /^\/projects\/new$/,
+    roles: [UserRole.CREATOR, UserRole.ADMIN],
+    permissions: ['project:create']
+  },
+  {
+    matcher: '/partners/:path*',
+    pattern: /^\/partners(?:\/.*)?$/,
+    roles: [UserRole.PARTNER, UserRole.ADMIN],
+    permissions: ['partner:manage']
+  },
+  {
+    matcher: '/api/projects/:path*',
+    pattern: /^\/api\/projects(?:\/.*)?$/,
+    roles: [UserRole.CREATOR, UserRole.ADMIN]
+  },
+  {
+    matcher: '/api/partners/:path*',
+    pattern: /^\/api\/partners(?:\/.*)?$/,
+    roles: [UserRole.PARTNER, UserRole.ADMIN],
+    permissions: ['partner:manage']
+  },
+  {
+    matcher: '/api/settlement/:path*',
+    pattern: /^\/api\/settlement(?:\/.*)?$/,
+    roles: [UserRole.ADMIN],
+    permissions: ['settlement:manage']
+  }
+];
+
+export const findMatchingGuard = (pathname: string) =>
+  ROLE_GUARDS.find(({ pattern }) => pattern.test(pathname));
+
+export type GuardSubject = {
+  role?: string | null;
+  permissions?: string[] | null;
+} | null;
+
+export const isAuthorizedForGuard = (subject: GuardSubject, guard: RoleGuard | undefined) => {
+  if (!guard) {
+    return true;
+  }
+
+  if (!subject) {
+    return false;
+  }
+
+  const role = normalizeRole(subject.role ?? null);
+  const permissions = Array.isArray(subject.permissions) ? subject.permissions : [];
+
+  const hasRequiredRole = guard.roles ? guard.roles.includes(role) : true;
+  const hasRequiredPermissions = guard.permissions
+    ? hasAllPermissions(permissions, guard.permissions)
+    : true;
+
+  return hasRequiredRole && hasRequiredPermissions;
+};
+
+export const canAccessRoute = (subject: GuardSubject, pathname: string) => {
+  const guard = findMatchingGuard(pathname);
+  return isAuthorizedForGuard(subject, guard);
+};

--- a/lib/server/moderation.ts
+++ b/lib/server/moderation.ts
@@ -1,0 +1,57 @@
+import {
+  ModerationStatus,
+  ModerationTargetType,
+  type ModerationReport
+} from '@/types/prisma';
+
+import { prisma } from '@/lib/prisma';
+
+export interface ModerationReportSummary {
+  id: string;
+  targetType: ModerationTargetType;
+  targetId: string;
+  status: ModerationStatus;
+  reason: string | null;
+  createdAt: Date;
+  reporter: {
+    id: string;
+    name: string | null;
+  } | null;
+}
+
+const ACTIVE_REVIEW_STATUSES: ModerationStatus[] = [
+  ModerationStatus.PENDING,
+  ModerationStatus.REVIEWING
+];
+
+type ReportWithRelations = ModerationReport & {
+  reporter: { id: string; name: string | null } | null;
+};
+
+const toSummary = (report: ReportWithRelations): ModerationReportSummary => ({
+  id: report.id,
+  targetType: report.targetType,
+  targetId: report.targetId,
+  status: report.status,
+  reason: report.reason ?? null,
+  createdAt: report.createdAt,
+  reporter: report.reporter
+    ? {
+        id: report.reporter.id,
+        name: report.reporter.name ?? null
+      }
+    : null
+});
+
+export const getOpenModerationReports = async (limit = 5) => {
+  const reports = await prisma.moderationReport.findMany({
+    where: { status: { in: ACTIVE_REVIEW_STATUSES } },
+    include: {
+      reporter: { select: { id: true, name: true } }
+    },
+    orderBy: { createdAt: 'desc' },
+    take: limit
+  });
+
+  return reports.map(toSummary);
+};

--- a/lib/server/partners.ts
+++ b/lib/server/partners.ts
@@ -267,6 +267,16 @@ export const listPartners = async (params: ListPartnersParams = {}): Promise<Lis
   };
 };
 
+export const getPartnersAwaitingApproval = async (limit = 5) => {
+  const result = await listPartners({
+    limit,
+    verified: false,
+    includeUnverified: true
+  });
+
+  return result.items;
+};
+
 export const getPartnerById = async (id: string): Promise<PartnerSummary | null> => {
   const partner = await prisma.partner.findUnique({
     where: { id },

--- a/lib/server/settlement-queries.ts
+++ b/lib/server/settlement-queries.ts
@@ -1,0 +1,49 @@
+import { SettlementPayoutStatus } from '@/types/prisma';
+
+import { prisma } from '@/lib/prisma';
+
+export interface SettlementSummary {
+  id: string;
+  projectId: string;
+  projectTitle: string;
+  totalRaised: number;
+  netAmount: number;
+  payoutStatus: SettlementPayoutStatus;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const toSummary = (settlement: {
+  id: string;
+  projectId: string;
+  totalRaised: number;
+  netAmount: number;
+  payoutStatus: SettlementPayoutStatus;
+  createdAt: Date;
+  updatedAt: Date;
+  project: { id: string; title: string };
+}): SettlementSummary => ({
+  id: settlement.id,
+  projectId: settlement.projectId,
+  projectTitle: settlement.project.title,
+  totalRaised: settlement.totalRaised,
+  netAmount: settlement.netAmount,
+  payoutStatus: settlement.payoutStatus,
+  createdAt: settlement.createdAt,
+  updatedAt: settlement.updatedAt
+});
+
+export const getSettlementsPendingPayout = async (limit = 5) => {
+  const settlements = await prisma.settlement.findMany({
+    where: {
+      payoutStatus: { in: [SettlementPayoutStatus.PENDING, SettlementPayoutStatus.IN_PROGRESS] }
+    },
+    include: {
+      project: { select: { id: true, title: true } }
+    },
+    orderBy: { updatedAt: 'desc' },
+    take: limit
+  });
+
+  return settlements.map(toSummary);
+};

--- a/tests/role-guards.test.ts
+++ b/tests/role-guards.test.ts
@@ -1,0 +1,32 @@
+import { canAccessRoute, findMatchingGuard } from '@/lib/auth/role-guards';
+import { UserRole } from '@/types/prisma';
+
+describe('ROLE_GUARDS', () => {
+  it('exposes admin guard requiring ADMIN role', () => {
+    const guard = findMatchingGuard('/admin');
+
+    expect(guard).toBeDefined();
+    expect(guard?.roles).toContain(UserRole.ADMIN);
+  });
+
+  it('prevents access when subject is missing', () => {
+    expect(canAccessRoute(null, '/admin')).toBe(false);
+  });
+
+  it('allows creator with permission to access project creation', () => {
+    const subject = { role: UserRole.CREATOR, permissions: ['project:create'] };
+
+    expect(canAccessRoute(subject, '/projects/new')).toBe(true);
+  });
+
+  it('denies creator lacking permission for guarded routes', () => {
+    const subject = { role: UserRole.CREATOR, permissions: [] as string[] };
+
+    expect(canAccessRoute(subject, '/projects/new')).toBe(false);
+  });
+
+  it('ignores guards for public routes', () => {
+    expect(canAccessRoute(null, '/')).toBe(true);
+    expect(canAccessRoute({ role: UserRole.PARTICIPANT, permissions: [] }, '/help')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add an admin dashboard layout with review, partner, report, and settlement sections backed by server queries
- centralize role guard definitions for reuse across middleware, navigation, and tests while updating shared navigation to show admin access only when permitted
- create access control unit tests aligned with middleware guard logic

## Testing
- npm test -- role-guards

------
https://chatgpt.com/codex/tasks/task_b_68d7e231f29883268cd69ef4c8f3d9f3