### PR TITLE
Implement partner registration submission UX

### DIFF
--- a/app/partners/page.tsx
+++ b/app/partners/page.tsx
@@ -1,10 +1,10 @@
 import { UserRole } from '@/types/prisma';
 
-import { PartnerForm } from '@/components/ui/forms/partner-form';
 import { requireUser } from '@/lib/auth/guards';
 import { ROLE_LABELS } from '@/lib/auth/permissions';
 import { listPartners } from '@/lib/server/partners';
 import { PARTNER_TYPE_LABELS } from '@/lib/validators/partners';
+import { PartnerRegistrationPanel } from './partner-registration-panel';
 
 const statusBadge = (verified: boolean) =>
   verified ? '승인' : '검수 중';
@@ -27,7 +27,7 @@ export default async function PartnersPage() {
         <h1 className="text-3xl font-semibold text-white">파트너 매칭</h1>
         <p className="mt-2 text-sm text-white/60">
           {user.name ? `${user.name} 파트너님, ` : ''}
-          스튜디오, 공연장, 제작사와 연결되어 프로젝트를 성공적으로 운영하세요. 등록 후에는 큐레이션 팀 검수를 거쳐 노출됩니다.
+          스튜디오, 공연장, 제작사와 연결되어 프로젝트를 성공적으로 운영하세요. 등록 요청이 접수되면 운영팀 검수를 거쳐 승인 결과를 알림으로 안내합니다.
         </p>
       </header>
 
@@ -65,15 +65,10 @@ export default async function PartnersPage() {
         <div>
           <h2 className="text-xl font-semibold text-white">파트너 등록</h2>
           <p className="mt-2 text-sm text-white/60">
-            협업 가능한 역량을 입력하면 프로젝트에 적합한 파트너로 추천됩니다.
+            협업 가능한 역량을 입력하면 프로젝트에 적합한 파트너로 추천됩니다. 요청 완료 후에는 검수 대기 상태가 표시됩니다.
           </p>
           <div className="mt-4 space-y-4">
-            <PartnerForm 
-              onSubmit={(data) => {
-                console.log('Partner form submitted:', data);
-                // TODO: Implement partner creation logic
-              }}
-            />
+            <PartnerRegistrationPanel />
             <div className="rounded-2xl border border-emerald-500/40 bg-emerald-500/10 p-4 text-sm text-emerald-100">
               <p className="font-medium text-emerald-200">권한 확인</p>
               <p className="mt-1 text-emerald-100/80">
@@ -81,7 +76,7 @@ export default async function PartnersPage() {
                 <span className="font-semibold">
                   {ROLE_LABELS[user.role as keyof typeof ROLE_LABELS]}
                 </span>
-                . 파트너 프로필 관리와 매칭 제안 응답 권한이 부여되었습니다.
+                . 승인 완료 시 파트너 대시보드에서 협업 제안과 매칭 알림을 바로 받아볼 수 있어요.
               </p>
             </div>
           </div>

--- a/app/partners/partner-registration-panel.tsx
+++ b/app/partners/partner-registration-panel.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { PartnerForm, type PartnerFormData } from '@/components/ui/forms/partner-form';
+
+const SUCCESS_MESSAGE =
+  '파트너 등록 신청이 접수되었습니다. 운영팀 검수 후 승인 결과를 알림으로 안내해 드릴게요.';
+const ERROR_FALLBACK_MESSAGE =
+  '파트너 등록 요청을 처리하지 못했어요. 잠시 후 다시 시도하거나 운영팀에 문의해 주세요.';
+
+type SubmissionStatus =
+  | { state: 'idle' }
+  | { state: 'success'; message: string }
+  | { state: 'error'; message: string };
+
+export function PartnerRegistrationPanel() {
+  const [status, setStatus] = useState<SubmissionStatus>({ state: 'idle' });
+
+  const handleSubmit = useCallback(async (data: PartnerFormData) => {
+    setStatus({ state: 'idle' });
+
+    const response = await fetch('/api/partners', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    });
+
+    if (!response.ok) {
+      let message = ERROR_FALLBACK_MESSAGE;
+
+      try {
+        const payload = await response.json();
+        if (payload?.message) {
+          message = payload.message;
+        }
+      } catch (error) {
+        // 응답 파싱 실패 시 기본 문구 유지
+      }
+
+      setStatus({ state: 'error', message });
+      throw new Error(message);
+    }
+  }, []);
+
+  const handleSuccess = useCallback(() => {
+    setStatus({ state: 'success', message: SUCCESS_MESSAGE });
+  }, []);
+
+  return (
+    <div className="space-y-4">
+      <PartnerForm onSubmit={handleSubmit} onSuccess={handleSuccess} />
+
+      {status.state === 'success' ? (
+        <div
+          className="rounded-2xl border border-emerald-500/40 bg-emerald-500/10 p-4 text-sm text-emerald-100"
+          role="status"
+          aria-live="polite"
+        >
+          <p className="font-medium text-emerald-200">검수 대기 중이에요</p>
+          <p className="mt-1 text-emerald-100/80">{status.message}</p>
+        </div>
+      ) : null}
+
+      {status.state === 'error' ? (
+        <div
+          className="rounded-2xl border border-rose-500/40 bg-rose-500/10 p-4 text-sm text-rose-100"
+          role="alert"
+        >
+          <p className="font-medium text-rose-200">등록 요청이 실패했어요</p>
+          <p className="mt-1 text-rose-100/80">{status.message}</p>
+        </div>
+      ) : null}
+
+      <div className="rounded-2xl border border-white/10 bg-white/5 p-4 text-xs text-white/70">
+        <p className="font-medium text-white">운영팀 검수 프로세스 안내</p>
+        <ul className="mt-2 list-disc space-y-1 pl-5">
+          <li>등록 요청 후 영업일 기준 1~2일 내에 큐레이션 팀이 검토해요.</li>
+          <li>승인되면 파트너 대시보드와 알림 센터에서 바로 확인할 수 있어요.</li>
+          <li>추가 자료가 필요하면 운영팀에서 보완 요청 알림을 보내드려요.</li>
+        </ul>
+      </div>
+    </div>
+  );
+}
+

--- a/components/ui/forms/partner-form.tsx
+++ b/components/ui/forms/partner-form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -8,126 +8,163 @@ import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { PartnerType } from '@/types/prisma';
 
-interface PartnerFormData {
-    name: string;
-    description: string;
-    type: PartnerType;
-    contactInfo: string;
-    location: string;
-    portfolioUrl: string;
-}
+export type PartnerFormData = {
+  name: string;
+  description: string;
+  type: PartnerType;
+  contactInfo: string;
+  location: string;
+  portfolioUrl: string;
+};
 
 interface PartnerFormProps {
-    onSubmit: (data: PartnerFormData) => void;
-    initialData?: Partial<PartnerFormData>;
-    isLoading?: boolean;
+  onSubmit: (data: PartnerFormData) => Promise<void>;
+  initialData?: Partial<PartnerFormData>;
+  onSuccess?: () => void;
 }
 
-export function PartnerForm({ onSubmit, initialData, isLoading = false }: PartnerFormProps) {
-    const [formData, setFormData] = useState<PartnerFormData>({
-        name: initialData?.name || '',
-        description: initialData?.description || '',
-        type: initialData?.type || PartnerType.STUDIO,
-        contactInfo: initialData?.contactInfo || '',
-        location: initialData?.location || '',
-        portfolioUrl: initialData?.portfolioUrl || '',
-    });
+const buildInitialValues = (initialData?: Partial<PartnerFormData>): PartnerFormData => ({
+  name: initialData?.name ?? '',
+  description: initialData?.description ?? '',
+  type: initialData?.type ?? PartnerType.STUDIO,
+  contactInfo: initialData?.contactInfo ?? '',
+  location: initialData?.location ?? '',
+  portfolioUrl: initialData?.portfolioUrl ?? ''
+});
 
-    const handleSubmit = (e: React.FormEvent) => {
-        e.preventDefault();
-        onSubmit(formData);
-    };
+const SUBMIT_ERROR_FALLBACK = '파트너 등록 요청을 완료하지 못했어요. 잠시 후 다시 시도해 주세요.';
 
-    const handleChange = (field: keyof PartnerFormData, value: string) => {
-        setFormData(prev => ({
-            ...prev,
-            [field]: value
-        }));
-    };
+export function PartnerForm({ onSubmit, initialData, onSuccess }: PartnerFormProps) {
+  const initialValues = useMemo(() => buildInitialValues(initialData), [initialData]);
+  const [formData, setFormData] = useState<PartnerFormData>(initialValues);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-    return (
-        <form onSubmit={handleSubmit} className="space-y-6">
-            <div className="space-y-2">
-                <Label htmlFor="name">파트너명 *</Label>
-                <Input
-                    id="name"
-                    value={formData.name}
-                    onChange={(e) => handleChange('name', e.target.value)}
-                    placeholder="파트너명을 입력하세요"
-                    required
-                />
-            </div>
+  useEffect(() => {
+    setFormData(initialValues);
+  }, [initialValues]);
 
-            <div className="space-y-2">
-                <Label htmlFor="description">설명</Label>
-                <Textarea
-                    id="description"
-                    value={formData.description}
-                    onChange={(e) => handleChange('description', e.target.value)}
-                    placeholder="파트너에 대한 설명을 입력하세요"
-                    rows={3}
-                />
-            </div>
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    setIsSubmitting(true);
 
-            <div className="space-y-2">
-                <Label htmlFor="type">파트너 유형 *</Label>
-                <Select
-                    value={formData.type}
-                    onValueChange={(value) => handleChange('type', value as PartnerType)}
-                >
-                    <SelectTrigger>
-                        <SelectValue placeholder="파트너 유형을 선택하세요" />
-                    </SelectTrigger>
-                    <SelectContent>
-                        <SelectItem value={PartnerType.STUDIO}>스튜디오</SelectItem>
-                        <SelectItem value={PartnerType.VENUE}>공연장</SelectItem>
-                        <SelectItem value={PartnerType.PRODUCTION}>제작 스튜디오</SelectItem>
-                        <SelectItem value={PartnerType.MERCHANDISE}>머천다이즈</SelectItem>
-                        <SelectItem value={PartnerType.OTHER}>기타</SelectItem>
-                    </SelectContent>
-                </Select>
-            </div>
+    try {
+      await onSubmit(formData);
+      setFormData(buildInitialValues(initialData));
+      onSuccess?.();
+    } catch (submissionError) {
+      if (submissionError instanceof Error && submissionError.message) {
+        setError(submissionError.message);
+      } else {
+        setError(SUBMIT_ERROR_FALLBACK);
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
 
-            <div className="space-y-2">
-                <Label htmlFor="contactInfo">연락처 *</Label>
-                <Input
-                    id="contactInfo"
-                    value={formData.contactInfo}
-                    onChange={(e) => handleChange('contactInfo', e.target.value)}
-                    placeholder="연락처를 입력하세요"
-                    required
-                />
-            </div>
+  const handleChange = (field: keyof PartnerFormData, value: string) => {
+    setFormData((prev) => ({
+      ...prev,
+      [field]: value
+    }));
+    if (error) {
+      setError(null);
+    }
+  };
 
-            <div className="space-y-2">
-                <Label htmlFor="location">위치</Label>
-                <Input
-                    id="location"
-                    value={formData.location}
-                    onChange={(e) => handleChange('location', e.target.value)}
-                    placeholder="위치를 입력하세요"
-                />
-            </div>
+  const handleReset = () => {
+    setFormData(buildInitialValues(initialData));
+    setError(null);
+  };
 
-            <div className="space-y-2">
-                <Label htmlFor="portfolioUrl">포트폴리오 URL</Label>
-                <Input
-                    id="portfolioUrl"
-                    type="url"
-                    value={formData.portfolioUrl}
-                    onChange={(e) => handleChange('portfolioUrl', e.target.value)}
-                    placeholder="https://example.com"
-                />
-            </div>
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6" noValidate>
+      <div className="space-y-2">
+        <Label htmlFor="name">파트너명 *</Label>
+        <Input
+          id="name"
+          value={formData.name}
+          onChange={(event) => handleChange('name', event.target.value)}
+          placeholder="파트너명을 입력하세요"
+          required
+        />
+      </div>
 
-            <div className="flex justify-end space-x-2">
-                <Button type="button" variant="outline">
-                    취소
-                </Button>
-                <Button type="submit" disabled={isLoading}>
-                    {isLoading ? '저장 중...' : '저장'}
-                </Button>
-            </div>
-        </form>
-    );
+      <div className="space-y-2">
+        <Label htmlFor="description">설명</Label>
+        <Textarea
+          id="description"
+          value={formData.description}
+          onChange={(event) => handleChange('description', event.target.value)}
+          placeholder="제공 서비스와 프로젝트 경험을 소개해 주세요"
+          rows={3}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="type">파트너 유형 *</Label>
+        <Select value={formData.type} onValueChange={(value) => handleChange('type', value as PartnerType)}>
+          <SelectTrigger>
+            <SelectValue placeholder="파트너 유형을 선택하세요" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={PartnerType.STUDIO}>스튜디오</SelectItem>
+            <SelectItem value={PartnerType.VENUE}>공연장</SelectItem>
+            <SelectItem value={PartnerType.PRODUCTION}>제작 스튜디오</SelectItem>
+            <SelectItem value={PartnerType.MERCHANDISE}>머천다이즈</SelectItem>
+            <SelectItem value={PartnerType.OTHER}>기타</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="contactInfo">연락처 *</Label>
+        <Input
+          id="contactInfo"
+          value={formData.contactInfo}
+          onChange={(event) => handleChange('contactInfo', event.target.value)}
+          placeholder="연락 가능한 이메일 또는 전화번호"
+          required
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="location">위치</Label>
+        <Input
+          id="location"
+          value={formData.location}
+          onChange={(event) => handleChange('location', event.target.value)}
+          placeholder="기반 지역을 입력하세요"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="portfolioUrl">포트폴리오 URL</Label>
+        <Input
+          id="portfolioUrl"
+          type="url"
+          value={formData.portfolioUrl}
+          onChange={(event) => handleChange('portfolioUrl', event.target.value)}
+          placeholder="https://example.com"
+        />
+      </div>
+
+      {error ? (
+        <p className="text-sm text-rose-300" role="alert" aria-live="assertive">
+          {error}
+        </p>
+      ) : null}
+
+      <div className="flex justify-end space-x-2">
+        <Button type="button" variant="outline" onClick={handleReset} disabled={isSubmitting}>
+          초기화
+        </Button>
+        <Button type="submit" disabled={isSubmitting}>
+          {isSubmitting ? '등록 요청 중…' : '파트너 등록 요청'}
+        </Button>
+      </div>
+    </form>
+  );
 }

--- a/tests/partner-create.integration.test.ts
+++ b/tests/partner-create.integration.test.ts
@@ -1,0 +1,106 @@
+import { PartnerType, UserRole } from '@/types/prisma';
+
+import { PartnerProfileExistsError, createPartnerProfile } from '@/lib/server/partners';
+
+jest.mock('next/cache', () => ({
+  revalidatePath: jest.fn()
+}));
+
+const { revalidatePath: mockRevalidatePath } = jest.requireMock('next/cache') as {
+  revalidatePath: jest.Mock;
+};
+
+jest.mock('@/lib/prisma', () => {
+  const prismaMocks = {
+    userFindUnique: jest.fn(),
+    partnerFindUnique: jest.fn(),
+    txPartnerCreate: jest.fn(),
+    txUserUpdate: jest.fn(),
+    transaction: jest.fn()
+  };
+
+  (globalThis as unknown as { __prismaMocks?: typeof prismaMocks }).__prismaMocks = prismaMocks;
+
+  return {
+    prisma: {
+      user: { findUnique: (...args: unknown[]) => prismaMocks.userFindUnique(...args) },
+      partner: { findUnique: (...args: unknown[]) => prismaMocks.partnerFindUnique(...args) },
+      $transaction: (callback: unknown) => prismaMocks.transaction(callback)
+    },
+    Prisma: { JsonNull: Symbol('JsonNull') }
+  };
+});
+
+const {
+  userFindUnique: mockUserFindUnique,
+  partnerFindUnique: mockPartnerFindUnique,
+  txPartnerCreate: mockTxPartnerCreate,
+  txUserUpdate: mockTxUserUpdate,
+  transaction: mockTransaction
+} = (globalThis as unknown as { __prismaMocks: {
+  userFindUnique: jest.Mock;
+  partnerFindUnique: jest.Mock;
+  txPartnerCreate: jest.Mock;
+  txUserUpdate: jest.Mock;
+  transaction: jest.Mock;
+}; }).__prismaMocks;
+
+describe('createPartnerProfile', () => {
+  const sessionUser = { id: 'user-1', role: UserRole.PARTICIPANT, permissions: [] } as const;
+  const basePayload = {
+    name: 'Studio Aurora',
+    type: PartnerType.STUDIO,
+    contactInfo: 'hello@aurora.studio'
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockTxPartnerCreate.mockResolvedValue({ id: 'partner-1' });
+    mockTxUserUpdate.mockResolvedValue(undefined);
+    mockTransaction.mockImplementation(async (callback: any) =>
+      callback({
+        partner: { create: mockTxPartnerCreate },
+        user: { update: mockTxUserUpdate }
+      })
+    );
+  });
+
+  it('updates the owner role to PARTNER after a successful creation', async () => {
+    const now = new Date();
+    mockUserFindUnique.mockResolvedValue({ id: sessionUser.id, role: UserRole.PARTICIPANT });
+    mockPartnerFindUnique
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        id: 'partner-1',
+        name: basePayload.name,
+        type: basePayload.type,
+        verified: false,
+        description: null,
+        location: null,
+        portfolioUrl: null,
+        contactInfo: basePayload.contactInfo,
+        createdAt: now,
+        updatedAt: now,
+        user: { id: sessionUser.id, name: null, avatarUrl: null, role: UserRole.PARTNER },
+        _count: { matches: 0 }
+      });
+    const result = await createPartnerProfile(basePayload, sessionUser);
+
+    expect(mockTxUserUpdate).toHaveBeenCalledWith({
+      where: { id: sessionUser.id },
+      data: { role: UserRole.PARTNER }
+    });
+    expect(result).toMatchObject({ id: 'partner-1', name: basePayload.name, matchCount: 0 });
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/partners');
+  });
+
+  it('prevents creating a duplicate partner profile', async () => {
+    mockUserFindUnique.mockResolvedValue({ id: sessionUser.id, role: UserRole.PARTNER });
+    mockPartnerFindUnique.mockResolvedValue({ id: 'partner-1' });
+
+    await expect(createPartnerProfile(basePayload, sessionUser)).rejects.toBeInstanceOf(
+      PartnerProfileExistsError
+    );
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- replace the partners page form handler with a client registration panel that calls the `/api/partners` endpoint and exposes review-state messaging
- enhance the shared PartnerForm with async submission support, inline error handling, and a success reset callback
- add integration coverage to ensure partner creation upgrades user roles and rejects duplicate profile requests

## Testing
- npm test -- --runTestsByPath tests/partner-create.integration.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68d7e22fd8f48326a5375e214a3ebe34