### PR TITLE
Require login for community comments

### DIFF
--- a/__tests__/api/community-comments.test.ts
+++ b/__tests__/api/community-comments.test.ts
@@ -1,0 +1,106 @@
+import { describe, beforeEach, afterEach, it, expect, jest } from '@jest/globals';
+import { NextRequest } from 'next/server';
+
+import { POST } from '@/app/api/community/[id]/comments/route';
+import { AuthorizationError } from '@/lib/auth/guards';
+
+jest.mock('@/lib/auth/guards', () => {
+  const actual = jest.requireActual('@/lib/auth/guards');
+  return {
+    ...actual,
+    requireApiUser: jest.fn()
+  };
+});
+
+jest.mock('@/lib/prisma', () => {
+  const mockPrisma = {
+    post: {
+      findUnique: jest.fn()
+    },
+    comment: {
+      create: jest.fn(),
+      findMany: jest.fn()
+    }
+  };
+
+  return {
+    __esModule: true,
+    prisma: mockPrisma,
+    default: mockPrisma
+  };
+});
+
+const { prisma: mockPrisma } = jest.requireMock('@/lib/prisma') as {
+  prisma: {
+    post: { findUnique: jest.Mock };
+    comment: { create: jest.Mock; findMany: jest.Mock };
+  };
+};
+
+describe('Community comments API', () => {
+  const requireApiUser = jest.requireMock('@/lib/auth/guards').requireApiUser as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 401 when the user is not authenticated', async () => {
+    requireApiUser.mockRejectedValueOnce(new AuthorizationError('인증이 필요합니다.', 401));
+
+    const request = new NextRequest('http://localhost/api/community/post-1/comments', {
+      method: 'POST',
+      body: JSON.stringify({ content: 'Hello world' })
+    });
+
+    const response = await POST(request, { params: { id: 'post-1' } });
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: '인증이 필요합니다.' });
+    expect(mockPrisma.comment.create).not.toHaveBeenCalled();
+  });
+
+  it('creates a comment for the authenticated user', async () => {
+    requireApiUser.mockResolvedValueOnce({
+      id: 'user-1',
+      name: 'Alice',
+      email: 'alice@example.com',
+      role: 'PARTICIPANT',
+      permissions: []
+    });
+
+    mockPrisma.post.findUnique.mockResolvedValueOnce({ id: 'post-1' });
+    const createdAt = new Date('2024-01-01T00:00:00Z');
+    mockPrisma.comment.create.mockResolvedValueOnce({
+      id: 'comment-1',
+      postId: 'post-1',
+      content: 'Hello world',
+      createdAt,
+      author: { name: 'Alice' }
+    });
+
+    const request = new NextRequest('http://localhost/api/community/post-1/comments', {
+      method: 'POST',
+      body: JSON.stringify({ content: 'Hello world' })
+    });
+
+    const response = await POST(request, { params: { id: 'post-1' } });
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(mockPrisma.comment.create).toHaveBeenCalledWith({
+      data: {
+        content: 'Hello world',
+        postId: 'post-1',
+        authorId: 'user-1'
+      },
+      include: { author: true }
+    });
+    expect(data).toEqual({
+      id: 'comment-1',
+      postId: 'post-1',
+      content: 'Hello world',
+      authorName: 'Alice',
+      createdAt: createdAt.toISOString()
+    });
+  });
+});

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -88,7 +88,9 @@
     "commentErrorMessage": "We couldn’t send your comment. Please try again.",
     "commentSubmitting": "Sending...",
     "commentSubmit": "Comment",
-    "defaultGuestName": "Guest"
+    "defaultGuestName": "Guest",
+    "commentLoginPrompt": "Sign in to share your thoughts in the comments.",
+    "commentUserLabel": "Your comment will be posted as {{name}}."
   },
   "partners": {
     "title": "Partner matching",

--- a/locales/ko/common.json
+++ b/locales/ko/common.json
@@ -88,7 +88,9 @@
     "commentErrorMessage": "댓글 등록에 실패했습니다. 다시 시도해주세요.",
     "commentSubmitting": "전송 중...",
     "commentSubmit": "댓글 남기기",
-    "defaultGuestName": "게스트"
+    "defaultGuestName": "게스트",
+    "commentLoginPrompt": "로그인 후 댓글을 남길 수 있습니다.",
+    "commentUserLabel": "{{name}} 님으로 댓글이 작성됩니다."
   },
   "partners": {
     "title": "파트너 매칭",

--- a/tests/community-board.test.tsx
+++ b/tests/community-board.test.tsx
@@ -1,0 +1,120 @@
+import { I18nextProvider } from 'react-i18next';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+
+jest.mock('next-auth/react', () => ({
+  useSession: jest.fn(),
+  signIn: jest.fn()
+}));
+
+import { CommunityBoard } from '@/components/ui/sections/community-board';
+import { initI18n } from '@/lib/i18n';
+import { useSession } from 'next-auth/react';
+
+describe('CommunityBoard comment permissions', () => {
+  const originalFetch = global.fetch;
+  const mockUseSession = useSession as unknown as jest.Mock;
+
+  const mockPosts = [
+    {
+      id: 'post-1',
+      title: '테스트 게시글',
+      content: '게시글 내용',
+      likes: 0,
+      comments: 0,
+      liked: false
+    }
+  ];
+  const mockComments: any[] = [];
+
+  const createFetchMock = () =>
+    jest.fn((input: RequestInfo | URL) => {
+      const isRequestObject = typeof Request !== 'undefined' && input instanceof Request;
+      const url = typeof input === 'string' ? input : isRequestObject ? input.url : input.toString();
+      const postsEndpoint = '/api/community?';
+      const commentsEndpoint = `/api/community/${mockPosts[0].id}/comments`;
+
+      if (url.includes(postsEndpoint)) {
+        return Promise.resolve(
+          new Response(JSON.stringify(mockPosts), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' }
+          })
+        );
+      }
+
+      if (url.includes(commentsEndpoint)) {
+        return Promise.resolve(
+          new Response(JSON.stringify(mockComments), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' }
+          })
+        );
+      }
+
+      return Promise.reject(new Error(`Unhandled fetch: ${url}`));
+    });
+
+  const renderComponent = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false }
+      }
+    });
+    queryClient.setQueryData(['community', { projectId: null, sort: 'recent' }], mockPosts);
+    queryClient.setQueryData(['community', 'comments', mockPosts[0].id], mockComments);
+    const i18n = initI18n();
+
+    return render(
+      <I18nextProvider i18n={i18n}>
+        <QueryClientProvider client={queryClient}>
+          <CommunityBoard />
+        </QueryClientProvider>
+      </I18nextProvider>
+    );
+  };
+
+  beforeEach(() => {
+    const fetchMock = createFetchMock();
+    (global.fetch as any) = fetchMock;
+    mockUseSession.mockReset();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch as typeof fetch;
+    jest.clearAllMocks();
+  });
+
+  it('disables the comment form and shows a login prompt for guests', async () => {
+    mockUseSession.mockReturnValue({ data: null, status: 'unauthenticated' });
+
+    renderComponent();
+
+    await screen.findByText('테스트 게시글');
+    const textarea = await screen.findByPlaceholderText('댓글을 입력하세요');
+    expect(textarea).toBeDisabled();
+    expect(screen.getByText('로그인 후 댓글을 남길 수 있습니다.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '로그인' })).toBeInTheDocument();
+  });
+
+  it('enables the comment form for authenticated users', async () => {
+    mockUseSession.mockReturnValue({
+      data: {
+        user: {
+          id: 'user-1',
+          name: '홍길동'
+        }
+      },
+      status: 'authenticated'
+    });
+
+    renderComponent();
+
+    await screen.findByText('테스트 게시글');
+    const textarea = await screen.findByPlaceholderText('댓글을 입력하세요');
+    expect(textarea).not.toBeDisabled();
+    expect(screen.getByText('홍길동 님으로 댓글이 작성됩니다.')).toBeInTheDocument();
+    expect(screen.queryByText('로그인 후 댓글을 남길 수 있습니다.')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- require an authenticated session before creating community comments on the API and remove the guest auto-provisioning fallback
- disable the community comment form for guests with a contextual login prompt and updated i18n copy
- cover the new permission flow with Jest API and React component tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d7e22f32ac8326a473cea287fbf008