### PR TITLE
Default signup users to participant role

### DIFF
--- a/__tests__/api/auth/register.test.ts
+++ b/__tests__/api/auth/register.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { NextRequest } from 'next/server';
+import { POST } from '@/app/api/auth/register/route';
+import { prisma } from '@/lib/prisma';
+import { UserRole } from '@/types/prisma';
+import { hash } from 'bcryptjs';
+
+jest.mock('@/lib/prisma', () => ({
+    prisma: {
+        user: {
+            findUnique: jest.fn(),
+            create: jest.fn(),
+        },
+    },
+}));
+
+jest.mock('bcryptjs', () => ({
+    hash: jest.fn(),
+}));
+
+describe('POST /api/auth/register', () => {
+    const mockedPrisma = prisma as unknown as {
+        user: {
+            findUnique: jest.Mock;
+            create: jest.Mock;
+        };
+    };
+    const mockedHash = hash as unknown as jest.Mock;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('ignores incoming role values and stores user as PARTICIPANT', async () => {
+        mockedPrisma.user.findUnique.mockResolvedValue(null);
+        mockedPrisma.user.create.mockResolvedValue({
+            id: 'user-1',
+            name: '테스트 사용자',
+            email: 'test@example.com',
+            role: UserRole.PARTICIPANT,
+            createdAt: new Date(),
+        });
+        mockedHash.mockResolvedValue('hashed-password');
+
+        const request = new NextRequest('http://localhost:3000/api/auth/register', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                name: '테스트 사용자',
+                email: 'test@example.com',
+                password: 'password123',
+                role: UserRole.CREATOR,
+            }),
+        });
+
+        const response = await POST(request);
+        const data = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(mockedPrisma.user.create).toHaveBeenCalledWith(
+            expect.objectContaining({
+                data: expect.objectContaining({
+                    role: UserRole.PARTICIPANT,
+                }),
+            })
+        );
+        expect(data.user.role).toBe(UserRole.PARTICIPANT);
+    });
+});

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -5,7 +5,8 @@ import { UserRole } from '@/types/prisma';
 
 export async function POST(request: NextRequest) {
     try {
-        const { name, email, password, role = 'PARTICIPANT' } = await request.json();
+        const body = await request.json();
+        const { name, email, password } = body;
 
         // 입력 검증
         if (!name || !email || !password) {
@@ -43,7 +44,7 @@ export async function POST(request: NextRequest) {
                 name,
                 email,
                 passwordHash: hashedPassword,
-                role: role as UserRole,
+                role: UserRole.PARTICIPANT,
             },
             select: {
                 id: true,

--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -10,14 +10,13 @@ export default function SignUpPage() {
         name: '',
         email: '',
         password: '',
-        confirmPassword: '',
-        role: 'PARTICIPANT' as 'PARTICIPANT' | 'CREATOR' | 'PARTNER'
+        confirmPassword: ''
     });
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState('');
     const router = useRouter();
 
-    const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         setFormData(prev => ({
             ...prev,
             [e.target.name]: e.target.value
@@ -53,7 +52,6 @@ export default function SignUpPage() {
                     name: formData.name,
                     email: formData.email,
                     password: formData.password,
-                    role: formData.role,
                 }),
             });
 
@@ -127,21 +125,11 @@ export default function SignUpPage() {
                             />
                         </div>
 
-                        <div>
-                            <label htmlFor="role" className="block text-sm font-medium text-gray-300">
-                                역할
-                            </label>
-                            <select
-                                id="role"
-                                name="role"
-                                value={formData.role}
-                                onChange={handleChange}
-                                className="mt-1 block w-full px-3 py-2 border border-gray-600 rounded-md shadow-sm bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent"
-                            >
-                                <option value="PARTICIPANT">참여자</option>
-                                <option value="CREATOR">크리에이터</option>
-                                <option value="PARTNER">파트너</option>
-                            </select>
+                        <div className="rounded-lg border border-white/10 bg-white/5 p-4 text-sm text-purple-100">
+                            <p className="font-medium">역할은 가입 후 전용 신청 플로우에서 전환해요</p>
+                            <p className="mt-1 text-xs text-purple-200/80">
+                                신규 가입은 참여자 역할로 시작되며, 파트너 또는 크리에이터로 활동하려면 전용 신청 절차를 통해 승인 요청을 보내주세요. 신청이 승인되면 계정 역할이 자동으로 업데이트됩니다.
+                            </p>
                         </div>
 
                         <div>


### PR DESCRIPTION
## Summary
- remove the role selector from the signup page and guide partner/creator onboarding through the dedicated application flow
- enforce the register API to always persist new accounts as participants regardless of the provided role
- add a unit test that verifies non-participant role payloads are stored as PARTICIPANT

## Testing
- npm test -- __tests__/api/auth/register.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68d7e22dc1788326a7677a08ecbe9c30