### PR TITLE
Enhance artist profile experience with follow actions

### DIFF
--- a/app/api/artists/[id]/follow/route.ts
+++ b/app/api/artists/[id]/follow/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { Prisma } from '@/types/prisma';
+
+import { getServerAuthSession } from '@/lib/auth/session';
+import { prisma } from '@/lib/prisma';
+
+const unauthorized = () =>
+  NextResponse.json({ message: 'Authentication required to follow artists.' }, { status: 401 });
+
+const cannotFollowSelf = () =>
+  NextResponse.json({ message: 'You cannot follow yourself.' }, { status: 400 });
+
+const getFollowerCount = (artistId: string) => prisma.userFollow.count({ where: { followingId: artistId } });
+
+const notFound = () => NextResponse.json({ message: 'Artist not found' }, { status: 404 });
+
+const ensureArtistExists = async (artistId: string) => {
+  const exists = await prisma.user.findUnique({ where: { id: artistId }, select: { id: true } });
+  return Boolean(exists);
+};
+
+export async function POST(_request: NextRequest, { params }: { params: { id: string } }) {
+  const session = await getServerAuthSession();
+
+  if (!session?.user?.id) {
+    return unauthorized();
+  }
+
+  const artistId = params.id;
+
+  if (session.user.id === artistId) {
+    return cannotFollowSelf();
+  }
+
+  if (!(await ensureArtistExists(artistId))) {
+    return notFound();
+  }
+
+  try {
+    await prisma.userFollow.create({
+      data: {
+        followerId: session.user.id,
+        followingId: artistId
+      }
+    });
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+      // Already following – ignore duplicate.
+    } else {
+      console.error('Failed to follow artist', error);
+      return NextResponse.json({ message: 'Could not follow artist.' }, { status: 500 });
+    }
+  }
+
+  const followerCount = await getFollowerCount(artistId);
+  return NextResponse.json({ followerCount, isFollowing: true });
+}
+
+export async function DELETE(_request: NextRequest, { params }: { params: { id: string } }) {
+  const session = await getServerAuthSession();
+
+  if (!session?.user?.id) {
+    return unauthorized();
+  }
+
+  const artistId = params.id;
+
+  if (session.user.id === artistId) {
+    return cannotFollowSelf();
+  }
+
+  if (!(await ensureArtistExists(artistId))) {
+    return notFound();
+  }
+
+  try {
+    await prisma.userFollow.delete({
+      where: {
+        followerId_followingId: {
+          followerId: session.user.id,
+          followingId: artistId
+        }
+      }
+    });
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
+      // Not following – ignore.
+    } else {
+      console.error('Failed to unfollow artist', error);
+      return NextResponse.json({ message: 'Could not unfollow artist.' }, { status: 500 });
+    }
+  }
+
+  const followerCount = await getFollowerCount(artistId);
+  return NextResponse.json({ followerCount, isFollowing: false });
+}

--- a/app/api/artists/[id]/route.ts
+++ b/app/api/artists/[id]/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { getArtistProfile } from '@/lib/server/artists';
+import { getServerAuthSession } from '@/lib/auth/session';
+
+export async function GET(_request: NextRequest, { params }: { params: { id: string } }) {
+  const session = await getServerAuthSession();
+  const profile = await getArtistProfile(params.id, session?.user ?? null);
+
+  if (!profile) {
+    return NextResponse.json({ message: 'Artist not found' }, { status: 404 });
+  }
+
+  return NextResponse.json(profile);
+}

--- a/app/api/community/route.ts
+++ b/app/api/community/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { prisma } from '@/lib/prisma';
+import { Prisma } from '@/types/prisma';
 
 import { addDemoCommunityPost, listDemoCommunityPosts } from '@/lib/data/community';
 
@@ -9,10 +10,21 @@ export async function GET(request: NextRequest) {
   const sortParam = searchParams.get('sort');
   const sort = sortParam === 'popular' ? 'popular' : 'recent';
   const projectId = searchParams.get('projectId') ?? undefined;
+  const authorId = searchParams.get('authorId') ?? undefined;
 
   try {
+    const where: Prisma.PostWhereInput = {};
+
+    if (projectId) {
+      where.projectId = projectId;
+    }
+
+    if (authorId) {
+      where.authorId = authorId;
+    }
+
     const posts = await prisma.post.findMany({
-      where: projectId ? { projectId } : undefined,
+      where,
       include: {
         _count: { select: { likes: true, comments: true } }
       },

--- a/app/artists/[id]/page.tsx
+++ b/app/artists/[id]/page.tsx
@@ -1,74 +1,16 @@
-import Image from 'next/image';
+import { notFound } from 'next/navigation';
 
-import { ProjectCard } from '@/components/ui/cards/project-card';
-import { getProjectSummaries } from '@/lib/server/projects';
-import type { ProjectSummary } from '@/lib/api/projects';
+import { ArtistProfileShell } from '@/components/artists/artist-profile-shell';
+import { getServerAuthSession } from '@/lib/auth/session';
+import { getArtistProfile } from '@/lib/server/artists';
 
 export default async function ArtistProfilePage({ params }: { params: { id: string } }) {
-  const artistProjects = await getProjectSummaries({ ownerId: params.id });
+  const session = await getServerAuthSession();
+  const profile = await getArtistProfile(params.id, session?.user ?? null);
 
-  return (
-    <div className="mx-auto flex max-w-5xl flex-col gap-12 px-4 pb-20">
-      <header className="pt-6">
-        <div className="flex items-center gap-6">
-          <div className="relative h-24 w-24 overflow-hidden rounded-full border border-white/20">
-            <Image
-              src="https://images.unsplash.com/photo-1521119989659-a83eee488004"
-              alt="Artist portrait"
-              fill
-              className="object-cover"
-            />
-          </div>
-          <div>
-            <h1 className="text-3xl font-semibold text-white">{params.id.toUpperCase()} 아티스트</h1>
-            <p className="mt-2 text-sm text-white/60">
-              팬들과 공동 제작하는 프로젝트를 통해 새로운 경험을 만드는 콜라보 아티스트입니다.
-            </p>
-          </div>
-        </div>
-      </header>
+  if (!profile) {
+    notFound();
+  }
 
-      <section className="grid gap-6 md:grid-cols-3">
-        <div className="rounded-3xl border border-white/10 bg-white/5 p-5">
-          <p className="text-xs text-white/60">누적 후원자</p>
-          <p className="mt-2 text-2xl font-semibold text-white">12,340</p>
-        </div>
-        <div className="rounded-3xl border border-white/10 bg-white/5 p-5">
-          <p className="text-xs text-white/60">총 프로젝트</p>
-          <p className="mt-2 text-2xl font-semibold text-white">8</p>
-        </div>
-        <div className="rounded-3xl border border-white/10 bg-white/5 p-5">
-          <p className="text-xs text-white/60">평균 달성률</p>
-          <p className="mt-2 text-2xl font-semibold text-white">132%</p>
-        </div>
-      </section>
-
-      <section>
-        <h2 className="text-xl font-semibold text-white">진행한 프로젝트</h2>
-        <div className="mt-6 grid gap-6 md:grid-cols-2">
-          {artistProjects.length === 0 ? (
-            <div className="rounded-3xl border border-white/10 bg-white/5 p-6 text-sm text-white/60">
-              아직 진행한 프로젝트가 없습니다.
-            </div>
-          ) : (
-            artistProjects.map((project: ProjectSummary) => <ProjectCard key={project.id} project={project} />)
-          )}
-        </div>
-      </section>
-
-      <section className="space-y-4">
-        <h2 className="text-xl font-semibold text-white">팬 Q&A</h2>
-        <div className="space-y-3 rounded-3xl border border-white/10 bg-white/5 p-6">
-          <div>
-            <p className="text-sm font-semibold text-white">Q. 이번 프로젝트에서 가장 기대되는 부분은?</p>
-            <p className="mt-1 text-sm text-white/70">팬들과 함께 만드는 메타버스 스테이지입니다.</p>
-          </div>
-          <div>
-            <p className="text-sm font-semibold text-white">Q. 협업하고 싶은 파트너는?</p>
-            <p className="mt-1 text-sm text-white/70">Immersive XR 경험을 가진 파트너를 찾고 있어요.</p>
-          </div>
-        </div>
-      </section>
-    </div>
-  );
+  return <ArtistProfileShell profile={profile} viewerId={session?.user?.id ?? null} />;
 }

--- a/components/artists/artist-metrics.tsx
+++ b/components/artists/artist-metrics.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface ArtistMetricsProps {
+  followerCount: number;
+  totalBackers: number;
+  projectCount: number;
+}
+
+const formatter = new Intl.NumberFormat();
+
+export function ArtistMetrics({ followerCount, totalBackers, projectCount }: ArtistMetricsProps) {
+  const { t } = useTranslation();
+  const items = useMemo(
+    () => [
+      {
+        id: 'followers',
+        label: t('artist.metrics.followers'),
+        value: formatter.format(followerCount)
+      },
+      {
+        id: 'backers',
+        label: t('artist.metrics.backers'),
+        value: formatter.format(totalBackers)
+      },
+      {
+        id: 'projects',
+        label: t('artist.metrics.projects'),
+        value: formatter.format(projectCount)
+      }
+    ],
+    [followerCount, totalBackers, projectCount, t]
+  );
+
+  return (
+    <section className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+      {items.map((item) => (
+        <article key={item.id} className="rounded-3xl border border-white/10 bg-white/5 p-5">
+          <p className="text-xs text-white/60">{item.label}</p>
+          <p className="mt-2 text-2xl font-semibold text-white">{item.value}</p>
+        </article>
+      ))}
+    </section>
+  );
+}

--- a/components/artists/artist-profile-shell.tsx
+++ b/components/artists/artist-profile-shell.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { useMemo, useState } from 'react';
+import * as Tabs from '@radix-ui/react-tabs';
+import { useTranslation } from 'react-i18next';
+
+import type { GetArtistProfileResult } from '@/lib/server/artists';
+import { FollowButton } from '@/components/artists/follow-button';
+import { ArtistMetrics } from '@/components/artists/artist-metrics';
+import { ArtistProjectUpdates } from '@/components/artists/project-updates';
+import { ExternalLinksGrid } from '@/components/artists/external-links-grid';
+import { LinkedEvents } from '@/components/artists/linked-events';
+import { ProjectCard } from '@/components/ui/cards/project-card';
+import { CommunityBoard } from '@/components/ui/sections/community-board';
+
+const DEFAULT_AVATAR = 'https://images.unsplash.com/photo-1521119989659-a83eee488004';
+
+const joinedFormatter = new Intl.DateTimeFormat(undefined, { month: 'long', year: 'numeric' });
+
+interface ArtistProfileShellProps {
+  profile: GetArtistProfileResult;
+  viewerId: string | null;
+}
+
+export function ArtistProfileShell({ profile, viewerId }: ArtistProfileShellProps) {
+  const { t } = useTranslation();
+  const [followerCount, setFollowerCount] = useState(profile.followerCount);
+  const canEdit = viewerId === profile.id;
+  const isAuthenticated = Boolean(viewerId);
+
+  const tabs = useMemo(
+    () => [
+      { value: 'overview', label: t('artist.tabs.overview') },
+      { value: 'projects', label: t('artist.tabs.projects') },
+      { value: 'updates', label: t('artist.tabs.updates') },
+      { value: 'community', label: t('artist.tabs.community') },
+      { value: 'portfolio', label: t('artist.tabs.portfolio') }
+    ],
+    [t]
+  );
+
+  return (
+    <div className="mx-auto flex max-w-6xl flex-col gap-12 px-4 pb-20">
+      <header className="pt-6">
+        <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+          <div className="flex items-center gap-5">
+            <div className="relative h-24 w-24 overflow-hidden rounded-full border border-white/20">
+              <Image
+                src={profile.avatarUrl ?? DEFAULT_AVATAR}
+                alt={t('artist.profile.avatarAlt', { name: profile.name })}
+                fill
+                className="object-cover"
+              />
+            </div>
+            <div>
+              <h1 className="text-3xl font-semibold text-white">{profile.name}</h1>
+              <p className="mt-2 text-sm text-white/60">
+                {profile.bio ?? t('artist.profile.emptyBio')}
+              </p>
+              <p className="mt-3 text-xs uppercase tracking-[0.2em] text-white/40">
+                {t('artist.profile.joined', { date: joinedFormatter.format(new Date(profile.createdAt)) })}
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center gap-3">
+            {canEdit ? (
+              <Link
+                href="/profile"
+                className="inline-flex items-center gap-2 rounded-full border border-white/20 px-5 py-2 text-sm font-semibold text-white transition hover:border-primary/40 hover:text-primary"
+              >
+                {t('artist.actions.editProfile')}
+              </Link>
+            ) : (
+              <FollowButton
+                artistId={profile.id}
+                initialIsFollowing={profile.isFollowing}
+                isAuthenticated={isAuthenticated}
+                onFollowerChange={setFollowerCount}
+              />
+            )}
+          </div>
+        </div>
+      </header>
+
+      <ArtistMetrics followerCount={followerCount} totalBackers={profile.totalBackers} projectCount={profile.projectCount} />
+
+      <Tabs.Root defaultValue="overview" className="space-y-6">
+        <Tabs.List className="flex flex-wrap gap-2 rounded-full bg-white/5 p-2">
+          {tabs.map((tab) => (
+            <Tabs.Trigger
+              key={tab.value}
+              value={tab.value}
+              className="rounded-full px-4 py-2 text-sm font-medium text-white/70 data-[state=active]:bg-primary data-[state=active]:text-primary-foreground"
+            >
+              {tab.label}
+            </Tabs.Trigger>
+          ))}
+        </Tabs.List>
+
+        <Tabs.Content value="overview" className="space-y-8">
+          <section className="rounded-3xl border border-white/10 bg-white/5 p-6 text-sm text-white/70">
+            {profile.bio ?? t('artist.profile.emptyBioDetailed')}
+          </section>
+          <section className="space-y-4">
+            <header className="flex items-center justify-between">
+              <h2 className="text-lg font-semibold text-white">{t('artist.events.title')}</h2>
+              {canEdit && profile.events.length > 0 ? (
+                <button
+                  type="button"
+                  className="text-xs font-semibold text-primary transition hover:text-primary/80"
+                >
+                  {t('artist.events.manageCta')}
+                </button>
+              ) : null}
+            </header>
+            <LinkedEvents events={profile.events} canEdit={canEdit} />
+          </section>
+          <section className="space-y-4">
+            <header className="flex items-center justify-between">
+              <h2 className="text-lg font-semibold text-white">{t('artist.links.title')}</h2>
+              {canEdit && profile.socialLinks.length > 0 ? (
+                <Link
+                  href="/profile"
+                  className="text-xs font-semibold text-primary transition hover:text-primary/80"
+                >
+                  {t('artist.links.manageCta')}
+                </Link>
+              ) : null}
+            </header>
+            <ExternalLinksGrid links={profile.socialLinks} canEdit={canEdit} />
+          </section>
+        </Tabs.Content>
+
+        <Tabs.Content value="projects" className="space-y-6">
+          {profile.projects.length === 0 ? (
+            <div className="rounded-3xl border border-dashed border-white/20 bg-white/5 p-6 text-sm text-white/60">
+              {t('artist.projects.empty')}
+            </div>
+          ) : (
+            <div className="grid gap-6 md:grid-cols-2">
+              {profile.projects.map((project) => (
+                <ProjectCard key={project.id} project={project} />
+              ))}
+            </div>
+          )}
+        </Tabs.Content>
+
+        <Tabs.Content value="updates">
+          <ArtistProjectUpdates updates={profile.updates} />
+        </Tabs.Content>
+
+        <Tabs.Content value="community">
+          <CommunityBoard authorId={profile.id} readOnly={!canEdit} />
+        </Tabs.Content>
+
+        <Tabs.Content value="portfolio">
+          <div className="rounded-3xl border border-white/10 bg-white/5 p-6 text-sm text-white/70">
+            {canEdit ? t('artist.portfolio.editablePlaceholder') : t('artist.portfolio.placeholder')}
+          </div>
+        </Tabs.Content>
+      </Tabs.Root>
+    </div>
+  );
+}

--- a/components/artists/external-links-grid.tsx
+++ b/components/artists/external-links-grid.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import Link from 'next/link';
+import { useTranslation } from 'react-i18next';
+
+import type { ArtistSocialLink } from '@/lib/server/artists';
+
+interface ExternalLinksGridProps {
+  links: ArtistSocialLink[];
+  canEdit: boolean;
+}
+
+export function ExternalLinksGrid({ links, canEdit }: ExternalLinksGridProps) {
+  const { t } = useTranslation();
+
+  if (links.length === 0) {
+    return (
+      <div className="flex flex-col gap-4 rounded-3xl border border-dashed border-white/20 bg-white/5 p-6 text-sm text-white/60">
+        <p>{t('artist.links.empty')}</p>
+        {canEdit ? (
+          <Link
+            href="/profile"
+            className="inline-flex w-fit items-center justify-center rounded-full bg-white/10 px-4 py-2 text-xs font-semibold text-white transition hover:bg-white/20"
+          >
+            {t('artist.links.addLink')}
+          </Link>
+        ) : null}
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2">
+      {links.map((link) => (
+        <Link
+          key={`${link.label}-${link.url}`}
+          href={link.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="group rounded-3xl border border-white/10 bg-white/5 p-5 transition hover:border-primary/40 hover:bg-primary/10"
+        >
+          <p className="text-xs uppercase tracking-[0.2em] text-white/40">{link.label}</p>
+          <p className="mt-2 text-sm font-semibold text-white group-hover:text-primary">{link.url}</p>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/components/artists/follow-button.tsx
+++ b/components/artists/follow-button.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { signIn } from 'next-auth/react';
+
+type FollowButtonProps = {
+  artistId: string;
+  initialIsFollowing: boolean;
+  isAuthenticated: boolean;
+  onFollowerChange?: (count: number) => void;
+};
+
+export function FollowButton({ artistId, initialIsFollowing, isAuthenticated, onFollowerChange }: FollowButtonProps) {
+  const { t } = useTranslation();
+  const [isFollowing, setIsFollowing] = useState(initialIsFollowing);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleToggle = async () => {
+    if (!isAuthenticated) {
+      await signIn();
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+      const method = isFollowing ? 'DELETE' : 'POST';
+      const response = await fetch(`/api/artists/${artistId}/follow`, { method });
+
+      if (!response.ok) {
+        throw new Error('Failed to toggle follow status');
+      }
+
+      const json = (await response.json()) as { followerCount: number; isFollowing: boolean };
+      setIsFollowing(json.isFollowing);
+      if (onFollowerChange) {
+        onFollowerChange(json.followerCount);
+      }
+    } catch (error) {
+      console.error('Failed to toggle follow state', error);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const label = isFollowing ? t('artist.actions.following') : t('artist.actions.follow');
+
+  return (
+    <button
+      type="button"
+      onClick={handleToggle}
+      disabled={isSubmitting}
+      aria-pressed={isFollowing}
+      className={`inline-flex items-center gap-2 rounded-full border px-5 py-2 text-sm font-semibold transition focus:outline-none focus:ring-2 focus:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-60 ${
+        isFollowing
+          ? 'border-white/40 bg-white/10 text-white hover:bg-white/20'
+          : 'border-primary bg-primary text-primary-foreground hover:bg-primary/90'
+      }`}
+    >
+      {isSubmitting ? t('artist.actions.processing') : label}
+    </button>
+  );
+}

--- a/components/artists/linked-events.tsx
+++ b/components/artists/linked-events.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { CalendarClock } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import type { ArtistEventSummary } from '@/lib/server/artists';
+
+interface LinkedEventsProps {
+  events: ArtistEventSummary[];
+  canEdit: boolean;
+}
+
+const dateTimeFormatter = new Intl.DateTimeFormat(undefined, {
+  dateStyle: 'medium',
+  timeStyle: 'short'
+});
+
+export function LinkedEvents({ events, canEdit }: LinkedEventsProps) {
+  const { t } = useTranslation();
+
+  if (events.length === 0) {
+    return (
+      <div className="flex flex-col gap-4 rounded-3xl border border-dashed border-white/20 bg-white/5 p-6 text-sm text-white/60">
+        <p>{t('artist.events.empty')}</p>
+        {canEdit ? (
+          <button
+            type="button"
+            className="inline-flex w-fit items-center gap-2 rounded-full bg-white/10 px-4 py-2 text-xs font-semibold text-white transition hover:bg-white/20"
+          >
+            {t('artist.events.createCta')}
+          </button>
+        ) : null}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {events.map((event) => (
+        <article key={event.id} className="flex flex-col gap-3 rounded-3xl border border-white/10 bg-white/5 p-5 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-3">
+            <CalendarClock className="h-10 w-10 text-primary" aria-hidden />
+            <div>
+              <h3 className="text-base font-semibold text-white">{event.title}</h3>
+              <p className="text-xs text-white/50">
+                {event.startsAt ? dateTimeFormatter.format(new Date(event.startsAt)) : t('artist.events.tbd')}
+              </p>
+              {event.location ? <p className="text-xs text-white/50">{event.location}</p> : null}
+            </div>
+          </div>
+          <div className="flex items-center gap-3">
+            {event.status ? (
+              <span className="rounded-full bg-white/10 px-3 py-1 text-xs uppercase tracking-[0.2em] text-white/60">
+                {event.status}
+              </span>
+            ) : null}
+            {event.url ? (
+              <a
+                href={event.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="rounded-full bg-primary px-4 py-2 text-xs font-semibold text-primary-foreground transition hover:bg-primary/90"
+              >
+                {t('artist.events.viewDetails')}
+              </a>
+            ) : null}
+          </div>
+        </article>
+      ))}
+    </div>
+  );
+}

--- a/components/artists/project-updates.tsx
+++ b/components/artists/project-updates.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type { ArtistProjectUpdate } from '@/lib/server/artists';
+
+const dateFormatter = new Intl.DateTimeFormat(undefined, {
+  dateStyle: 'medium'
+});
+
+interface ProjectUpdatesProps {
+  updates: ArtistProjectUpdate[];
+}
+
+export function ArtistProjectUpdates({ updates }: ProjectUpdatesProps) {
+  const { t } = useTranslation();
+  const sorted = useMemo(
+    () => [...updates].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()),
+    [updates]
+  );
+
+  if (sorted.length === 0) {
+    return (
+      <div className="rounded-3xl border border-dashed border-white/20 bg-white/5 p-6 text-sm text-white/60">
+        {t('artist.updates.empty')}
+      </div>
+    );
+  }
+
+  return (
+    <ul className="space-y-4">
+      {sorted.map((update) => (
+        <li key={update.id} className="rounded-3xl border border-white/10 bg-white/5 p-6">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <h3 className="text-lg font-semibold text-white">{update.title}</h3>
+              <p className="mt-2 text-sm text-white/70">{update.excerpt}</p>
+              {update.projectTitle ? (
+                <p className="mt-3 text-xs uppercase tracking-[0.2em] text-white/40">
+                  {t('artist.updates.projectLabel', { title: update.projectTitle })}
+                </p>
+              ) : null}
+            </div>
+            <time className="text-xs text-white/50" dateTime={update.createdAt}>
+              {dateFormatter.format(new Date(update.createdAt))}
+            </time>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/lib/server/artists.ts
+++ b/lib/server/artists.ts
@@ -1,0 +1,232 @@
+import { randomUUID } from 'crypto';
+import { cache } from 'react';
+import { Prisma, PostType } from '@/types/prisma';
+
+import type { SessionUser } from '@/lib/auth/session';
+import { prisma } from '@/lib/prisma';
+import { getProjectSummaries } from '@/lib/server/projects';
+
+export interface ArtistSocialLink {
+  label: string;
+  url: string;
+}
+
+export interface ArtistProjectUpdate {
+  id: string;
+  title: string;
+  excerpt: string;
+  createdAt: string;
+  projectId?: string | null;
+  projectTitle?: string | null;
+}
+
+export interface ArtistEventSummary {
+  id: string;
+  title: string;
+  startsAt?: string | null;
+  status?: string | null;
+  location?: string | null;
+  url?: string | null;
+}
+
+export interface ArtistProfile {
+  id: string;
+  name: string;
+  avatarUrl: string | null;
+  bio: string | null;
+  followerCount: number;
+  totalBackers: number;
+  projectCount: number;
+  projects: Awaited<ReturnType<typeof getProjectSummaries>>;
+  socialLinks: ArtistSocialLink[];
+  updates: ArtistProjectUpdate[];
+  events: ArtistEventSummary[];
+  isFollowing: boolean;
+  createdAt: string;
+}
+
+const parseSocialLinks = (links: Prisma.JsonValue | null): ArtistSocialLink[] => {
+  if (!links) {
+    return [];
+  }
+
+  if (Array.isArray(links)) {
+    return links
+      .map((item) => {
+        if (!item || typeof item !== 'object') {
+          return null;
+        }
+
+        const label = 'label' in item && typeof item.label === 'string' ? item.label : null;
+        const url = 'url' in item && typeof item.url === 'string' ? item.url : null;
+
+        if (!label || !url) {
+          return null;
+        }
+
+        return { label, url } satisfies ArtistSocialLink;
+      })
+      .filter((item): item is ArtistSocialLink => Boolean(item));
+  }
+
+  if (typeof links === 'object') {
+    return Object.entries(links as Record<string, unknown>)
+      .map(([label, value]) => {
+        if (typeof value !== 'string' || !value.trim()) {
+          return null;
+        }
+
+        return { label, url: value } satisfies ArtistSocialLink;
+      })
+      .filter((item): item is ArtistSocialLink => Boolean(item));
+  }
+
+  return [];
+};
+
+const fetchArtistEvents = async (artistId: string): Promise<ArtistEventSummary[]> => {
+  const eventClient = (prisma as unknown as {
+    eventRegistration?: {
+      findMany: (args: { where?: Record<string, unknown>; orderBy?: Record<string, unknown> }) => Promise<unknown[]>;
+    };
+  }).eventRegistration;
+
+  if (!eventClient) {
+    return [];
+  }
+
+  try {
+    const events = await eventClient.findMany({
+      where: {
+        OR: [
+          { artistId },
+          { userId: artistId },
+          { ownerId: artistId }
+        ]
+      },
+      orderBy: { createdAt: 'desc' }
+    });
+
+    return events.map((event: any) => {
+      const title =
+        typeof event?.title === 'string'
+          ? event.title
+          : typeof event?.name === 'string'
+            ? event.name
+            : 'Untitled event';
+
+      return {
+        id: String(event?.id ?? randomUUID()),
+        title,
+        startsAt:
+          typeof event?.startsAt === 'string'
+            ? event.startsAt
+            : event?.startsAt instanceof Date
+              ? event.startsAt.toISOString()
+              : null,
+        status: typeof event?.status === 'string' ? event.status : null,
+        location: typeof event?.location === 'string' ? event.location : null,
+        url: typeof event?.url === 'string' ? event.url : null
+      } satisfies ArtistEventSummary;
+    });
+  } catch (error) {
+    console.warn('EventRegistration lookup failed, returning empty array.', error);
+    return [];
+  }
+};
+
+const fetchArtistUpdates = async (artistId: string): Promise<ArtistProjectUpdate[]> => {
+  const updates = await prisma.post.findMany({
+    where: { authorId: artistId, type: PostType.UPDATE },
+    include: { project: { select: { id: true, title: true } } },
+    orderBy: { createdAt: 'desc' },
+    take: 12
+  });
+
+  return updates.map((update) => ({
+    id: update.id,
+    title: update.title,
+    excerpt: update.excerpt ?? update.content.slice(0, 160),
+    createdAt: update.createdAt.toISOString(),
+    projectId: update.projectId,
+    projectTitle: update.project?.title ?? null
+  } satisfies ArtistProjectUpdate));
+};
+
+const fetchArtistStats = async (artistId: string) => {
+  const [followerCount, projectCount, uniqueBackers] = await Promise.all([
+    prisma.userFollow.count({ where: { followingId: artistId } }),
+    prisma.project.count({ where: { ownerId: artistId } }),
+    prisma.funding.groupBy({
+      by: ['userId'],
+      where: { project: { ownerId: artistId } }
+    })
+  ]);
+
+  return {
+    followerCount,
+    projectCount,
+    totalBackers: uniqueBackers.length
+  };
+};
+
+const fetchIsFollowing = async (artistId: string, viewer?: SessionUser | null) => {
+  if (!viewer?.id || viewer.id === artistId) {
+    return false;
+  }
+
+  const follow = await prisma.userFollow.findUnique({
+    where: {
+      followerId_followingId: {
+        followerId: viewer.id,
+        followingId: artistId
+      }
+    }
+  });
+
+  return Boolean(follow);
+};
+
+export const getArtistProfile = cache(async (artistId: string, viewer?: SessionUser | null) => {
+  const artist = await prisma.user.findUnique({
+    where: { id: artistId },
+    select: {
+      id: true,
+      name: true,
+      avatarUrl: true,
+      bio: true,
+      socialLinks: true,
+      createdAt: true
+    }
+  });
+
+  if (!artist) {
+    return null;
+  }
+
+  const [projects, stats, updates, events, isFollowing] = await Promise.all([
+    getProjectSummaries({ ownerId: artistId }),
+    fetchArtistStats(artistId),
+    fetchArtistUpdates(artistId),
+    fetchArtistEvents(artistId),
+    fetchIsFollowing(artistId, viewer)
+  ]);
+
+  return {
+    id: artist.id,
+    name: artist.name,
+    avatarUrl: artist.avatarUrl ?? null,
+    bio: artist.bio ?? null,
+    followerCount: stats.followerCount,
+    totalBackers: stats.totalBackers,
+    projectCount: stats.projectCount,
+    projects,
+    socialLinks: parseSocialLinks(artist.socialLinks),
+    updates,
+    events,
+    isFollowing,
+    createdAt: artist.createdAt.toISOString()
+  } satisfies ArtistProfile;
+});
+
+export type GetArtistProfileResult = NonNullable<Awaited<ReturnType<typeof getArtistProfile>>>;

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -92,6 +92,57 @@
     "commentLoginPrompt": "Sign in to share your thoughts in the comments.",
     "commentUserLabel": "Your comment will be posted as {{name}}."
   },
+  "artist": {
+    "actions": {
+      "follow": "Follow",
+      "following": "Following",
+      "processing": "Updating...",
+      "editProfile": "Edit profile"
+    },
+    "metrics": {
+      "followers": "Followers",
+      "backers": "Total backers",
+      "projects": "Projects"
+    },
+    "tabs": {
+      "overview": "Overview",
+      "projects": "Projects",
+      "updates": "Updates",
+      "community": "Community",
+      "portfolio": "Portfolio"
+    },
+    "profile": {
+      "avatarAlt": "{{name}} profile photo",
+      "emptyBio": "The artist has not added a bio yet.",
+      "emptyBioDetailed": "This artist has not shared an introduction yet. Follow them to stay updated on upcoming projects and announcements.",
+      "joined": "Joined in {{date}}"
+    },
+    "events": {
+      "title": "Linked events",
+      "manageCta": "Manage events",
+      "empty": "No events are linked to this profile yet.",
+      "createCta": "Create an event",
+      "tbd": "Schedule to be announced",
+      "viewDetails": "View details"
+    },
+    "links": {
+      "title": "External links",
+      "manageCta": "Manage links",
+      "empty": "Add official channels, merch stores or socials to help fans discover you.",
+      "addLink": "Add link"
+    },
+    "projects": {
+      "empty": "There are no published projects yet."
+    },
+    "updates": {
+      "empty": "No project updates have been posted yet.",
+      "projectLabel": "Posted for {{title}}"
+    },
+    "portfolio": {
+      "placeholder": "Portfolio content will appear here once the artist shares it.",
+      "editablePlaceholder": "Upload case studies, media kits or past work to curate your public portfolio."
+    }
+  },
   "partners": {
     "title": "Partner matching",
     "submit": "Submit partner",

--- a/locales/ko/common.json
+++ b/locales/ko/common.json
@@ -92,6 +92,57 @@
     "commentLoginPrompt": "로그인 후 댓글을 남길 수 있습니다.",
     "commentUserLabel": "{{name}} 님으로 댓글이 작성됩니다."
   },
+  "artist": {
+    "actions": {
+      "follow": "팔로우",
+      "following": "팔로잉",
+      "processing": "처리 중...",
+      "editProfile": "프로필 편집"
+    },
+    "metrics": {
+      "followers": "팔로워",
+      "backers": "누적 후원자",
+      "projects": "프로젝트"
+    },
+    "tabs": {
+      "overview": "소개",
+      "projects": "프로젝트",
+      "updates": "업데이트",
+      "community": "커뮤니티",
+      "portfolio": "포트폴리오"
+    },
+    "profile": {
+      "avatarAlt": "{{name}} 프로필 사진",
+      "emptyBio": "아직 소개가 등록되지 않았습니다.",
+      "emptyBioDetailed": "아직 소개글이 없습니다. 팔로우하고 새 소식을 받아보세요.",
+      "joined": "가입 {{date}}"
+    },
+    "events": {
+      "title": "연결된 이벤트",
+      "manageCta": "이벤트 관리",
+      "empty": "아직 연결된 이벤트가 없습니다.",
+      "createCta": "이벤트 만들기",
+      "tbd": "일정 추후 공개",
+      "viewDetails": "상세 보기"
+    },
+    "links": {
+      "title": "외부 링크",
+      "manageCta": "링크 관리",
+      "empty": "공식 채널과 SNS, 굿즈 스토어를 연결해 팬들이 쉽게 찾을 수 있게 하세요.",
+      "addLink": "링크 추가"
+    },
+    "projects": {
+      "empty": "등록된 프로젝트가 없습니다."
+    },
+    "updates": {
+      "empty": "게시된 프로젝트 업데이트가 없습니다.",
+      "projectLabel": "{{title}} 업데이트"
+    },
+    "portfolio": {
+      "placeholder": "아티스트가 자료를 등록하면 포트폴리오가 표시됩니다.",
+      "editablePlaceholder": "케이스 스터디, 미디어 킷 등 포트폴리오 자료를 추가해보세요."
+    }
+  },
   "partners": {
     "title": "파트너 매칭",
     "submit": "파트너 등록",

--- a/tests/artist-follow-button.test.tsx
+++ b/tests/artist-follow-button.test.tsx
@@ -1,0 +1,69 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+
+import { FollowButton } from '@/components/artists/follow-button';
+import { initI18n } from '@/lib/i18n';
+
+jest.mock('next-auth/react', () => ({
+  signIn: jest.fn()
+}));
+
+const { signIn } = jest.requireMock('next-auth/react');
+
+describe('FollowButton', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    (signIn as jest.Mock).mockReset();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch as typeof fetch;
+  });
+
+  const renderComponent = (props: React.ComponentProps<typeof FollowButton>) => {
+    const i18n = initI18n();
+    return render(
+      <I18nextProvider i18n={i18n}>
+        <FollowButton {...props} />
+      </I18nextProvider>
+    );
+  };
+
+  it('calls the follow API and toggles state', async () => {
+    const callback = jest.fn();
+    const mockFetch = jest.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const method = init?.method ?? 'GET';
+      const responseBody =
+        method === 'POST'
+          ? { followerCount: 5, isFollowing: true }
+          : { followerCount: 4, isFollowing: false };
+      return Promise.resolve({
+        ok: true,
+        json: async () => responseBody
+      } as Response);
+    });
+    global.fetch = mockFetch as typeof fetch;
+
+    renderComponent({ artistId: 'artist-1', initialIsFollowing: false, isAuthenticated: true, onFollowerChange: callback });
+
+    const button = screen.getByRole('button', { name: '팔로우' });
+    fireEvent.click(button);
+
+    await waitFor(() => expect(button).toHaveAttribute('aria-pressed', 'true'));
+    expect(button).toHaveTextContent('팔로잉');
+    expect(callback).toHaveBeenCalledWith(5);
+
+    fireEvent.click(button);
+    await waitFor(() => expect(button).toHaveAttribute('aria-pressed', 'false'));
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(callback).toHaveBeenLastCalledWith(4);
+  });
+
+  it('prompts sign in when unauthenticated', async () => {
+    renderComponent({ artistId: 'artist-1', initialIsFollowing: false, isAuthenticated: false });
+    const button = screen.getByRole('button', { name: '팔로우' });
+    fireEvent.click(button);
+    await waitFor(() => expect(signIn).toHaveBeenCalled());
+  });
+});

--- a/tests/artist-layout.test.tsx
+++ b/tests/artist-layout.test.tsx
@@ -1,0 +1,20 @@
+import { render } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+
+import { ArtistMetrics } from '@/components/artists/artist-metrics';
+import { initI18n } from '@/lib/i18n';
+
+describe('ArtistMetrics layout', () => {
+  it('uses responsive grid classes', () => {
+    const i18n = initI18n();
+    const { container } = render(
+      <I18nextProvider i18n={i18n}>
+        <ArtistMetrics followerCount={1234} totalBackers={5678} projectCount={9} />
+      </I18nextProvider>
+    );
+
+    const section = container.querySelector('section');
+    expect(section).toHaveClass('grid');
+    expect(section).toHaveClass('md:grid-cols-3');
+  });
+});

--- a/tests/artist-updates.test.tsx
+++ b/tests/artist-updates.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+
+import { ArtistProjectUpdates } from '@/components/artists/project-updates';
+import { initI18n } from '@/lib/i18n';
+
+describe('ArtistProjectUpdates', () => {
+  const renderComponent = (updates: any[]) => {
+    const i18n = initI18n();
+    return render(
+      <I18nextProvider i18n={i18n}>
+        <ArtistProjectUpdates updates={updates} />
+      </I18nextProvider>
+    );
+  };
+
+  it('renders an empty state when there are no updates', () => {
+    renderComponent([]);
+    expect(screen.getByText('게시된 프로젝트 업데이트가 없습니다.')).toBeInTheDocument();
+  });
+
+  it('renders update cards with project labels', () => {
+    renderComponent([
+      {
+        id: 'update-1',
+        title: '새로운 공연 일정',
+        excerpt: '10월 둘째 주 실황 녹화 진행',
+        createdAt: new Date('2024-01-01T00:00:00Z').toISOString(),
+        projectId: 'project-1',
+        projectTitle: '팬과 함께 만드는 라이브'
+      }
+    ]);
+
+    expect(screen.getByText('새로운 공연 일정')).toBeInTheDocument();
+    expect(screen.getByText('팬과 함께 만드는 라이브 업데이트')).toBeInTheDocument();
+  });
+});

--- a/tests/community-board.test.tsx
+++ b/tests/community-board.test.tsx
@@ -62,7 +62,7 @@ describe('CommunityBoard comment permissions', () => {
         mutations: { retry: false }
       }
     });
-    queryClient.setQueryData(['community', { projectId: null, sort: 'recent' }], mockPosts);
+    queryClient.setQueryData(['community', { projectId: null, authorId: null, sort: 'recent' }], mockPosts);
     queryClient.setQueryData(['community', 'comments', mockPosts[0].id], mockComments);
     const i18n = initI18n();
 


### PR DESCRIPTION
## Summary
- add a server artist profile helper with aggregated stats, updates, events, and follow state plus API endpoints to expose and mutate data
- refactor the artist profile page with dedicated client components for metrics, updates, events, external links, and follow controls while wiring community content by author
- extend community APIs, locale strings, and add component tests covering follow toggles, update empty states, and responsive layout

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_b_68d7fda3b5f08326a14b0b83b339050e