### PR TITLE
Add announcements system with admin tools

### DIFF
--- a/app/admin/announcements/_components/announcement-composer.tsx
+++ b/app/admin/announcements/_components/announcement-composer.tsx
@@ -1,0 +1,221 @@
+'use client';
+
+import { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import {
+  ANNOUNCEMENT_CATEGORIES,
+  DEFAULT_ANNOUNCEMENT_CATEGORY,
+  type AnnouncementCategory
+} from '@/lib/constants/announcements';
+
+interface AnnouncementFormState {
+  title: string;
+  content: string;
+  category: AnnouncementCategory;
+  isPinned: boolean;
+  publishedAt: string;
+}
+
+const initialState: AnnouncementFormState = {
+  title: '',
+  content: '',
+  category: DEFAULT_ANNOUNCEMENT_CATEGORY,
+  isPinned: false,
+  publishedAt: ''
+};
+
+async function createAnnouncementRequest(payload: AnnouncementFormState) {
+  const response = await fetch('/api/announcements', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      title: payload.title,
+      content: payload.content,
+      category: payload.category,
+      isPinned: payload.isPinned,
+      publishedAt: payload.publishedAt ? new Date(payload.publishedAt).toISOString() : null
+    })
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ message: '공지 작성에 실패했습니다.' }));
+    throw new Error(error.message ?? '공지 작성에 실패했습니다.');
+  }
+
+  return response.json();
+}
+
+export function AnnouncementComposer() {
+  const [formState, setFormState] = useState<AnnouncementFormState>(initialState);
+  const [error, setError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: createAnnouncementRequest,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['announcements', 'admin'] });
+      queryClient.invalidateQueries({ queryKey: ['announcements'] });
+      setFormState(initialState);
+    }
+  });
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+
+    if (!formState.title.trim() || !formState.content.trim()) {
+      setError('제목과 내용을 모두 입력해 주세요.');
+      return;
+    }
+
+    try {
+      await mutation.mutateAsync(formState);
+    } catch (submissionError) {
+      if (submissionError instanceof Error) {
+        setError(submissionError.message);
+      } else {
+        setError('공지 작성 중 오류가 발생했습니다.');
+      }
+    }
+  };
+
+  const handleChange = (field: keyof AnnouncementFormState, value: string | boolean) => {
+    setFormState((prev) => ({
+      ...prev,
+      [field]: value
+    }));
+  };
+
+  const previewDate = formState.publishedAt
+    ? new Date(formState.publishedAt)
+    : new Date();
+
+  return (
+    <div className="rounded-3xl border border-white/10 bg-white/[0.03] p-8 shadow-lg shadow-blue-500/5">
+      <h2 className="text-xl font-semibold text-white">새 공지 작성</h2>
+      <p className="mt-1 text-sm text-white/60">
+        공지 제목, 카테고리, 발행 시각을 설정하고 실시간으로 미리보기를 확인하세요.
+      </p>
+
+      <form onSubmit={handleSubmit} className="mt-6 grid gap-6 lg:grid-cols-[1fr_320px]">
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <label htmlFor="title" className="text-sm font-medium text-white/80">
+              제목
+            </label>
+            <input
+              id="title"
+              type="text"
+              value={formState.title}
+              onChange={(event) => handleChange('title', event.target.value)}
+              className="w-full rounded-lg border border-white/10 bg-white/[0.04] px-4 py-3 text-sm text-white placeholder-white/40 focus:border-blue-400 focus:outline-none"
+              placeholder="예: 8월 정기 점검 안내"
+              required
+            />
+          </div>
+
+          <div className="grid gap-4 lg:grid-cols-2">
+            <div className="space-y-2">
+              <label htmlFor="category" className="text-sm font-medium text-white/80">
+                카테고리
+              </label>
+              <select
+                id="category"
+                value={formState.category}
+                onChange={(event) => handleChange('category', event.target.value as AnnouncementCategory)}
+                className="w-full rounded-lg border border-white/10 bg-white/[0.04] px-4 py-3 text-sm text-white focus:border-blue-400 focus:outline-none"
+              >
+                {ANNOUNCEMENT_CATEGORIES.map((category) => (
+                  <option key={category.value} value={category.value}>
+                    {category.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="space-y-2">
+              <label htmlFor="publishedAt" className="text-sm font-medium text-white/80">
+                발행 시각 (비워두면 즉시 발행)
+              </label>
+              <input
+                id="publishedAt"
+                type="datetime-local"
+                value={formState.publishedAt}
+                onChange={(event) => handleChange('publishedAt', event.target.value)}
+                className="w-full rounded-lg border border-white/10 bg-white/[0.04] px-4 py-3 text-sm text-white focus:border-blue-400 focus:outline-none"
+              />
+            </div>
+          </div>
+
+          <div className="flex items-center gap-3">
+            <input
+              id="isPinned"
+              type="checkbox"
+              checked={formState.isPinned}
+              onChange={(event) => handleChange('isPinned', event.target.checked)}
+              className="h-4 w-4 rounded border border-white/30 bg-white/5 text-blue-400 focus:ring-blue-400"
+            />
+            <label htmlFor="isPinned" className="text-sm text-white/70">
+              공지를 상단에 고정합니다.
+            </label>
+          </div>
+
+          <div className="space-y-2">
+            <label htmlFor="content" className="text-sm font-medium text-white/80">
+              내용
+            </label>
+            <textarea
+              id="content"
+              value={formState.content}
+              onChange={(event) => handleChange('content', event.target.value)}
+              className="h-48 w-full rounded-lg border border-white/10 bg-white/[0.04] px-4 py-3 text-sm text-white placeholder-white/40 focus:border-blue-400 focus:outline-none"
+              placeholder="공지 내용을 작성해 주세요."
+              required
+            />
+          </div>
+
+          {error ? <p className="text-sm text-rose-300">{error}</p> : null}
+
+          <button
+            type="submit"
+            disabled={mutation.isPending}
+            className="inline-flex items-center justify-center rounded-lg bg-blue-500 px-5 py-3 text-sm font-medium text-white transition hover:bg-blue-400 disabled:cursor-not-allowed disabled:bg-blue-500/50"
+          >
+            {mutation.isPending ? '등록 중…' : '공지 발행' }
+          </button>
+        </div>
+
+        <aside className="hidden rounded-2xl border border-white/10 bg-white/[0.02] p-6 text-sm text-white/70 shadow-inner lg:block">
+          <h3 className="text-sm font-semibold text-white">미리보기</h3>
+          <p className="mt-1 text-xs text-white/50">
+            {formState.publishedAt ? `예약 발행: ${new Date(formState.publishedAt).toLocaleString('ko-KR')}` : '즉시 발행 예정'}
+          </p>
+          <div className="mt-5 space-y-3">
+            <div className="flex items-center gap-2 text-xs text-white/60">
+              {formState.isPinned ? (
+                <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-2 py-0.5 text-amber-300">
+                  📌 상단 고정
+                </span>
+              ) : null}
+              <span className="inline-flex items-center gap-1 rounded-full bg-white/5 px-2 py-0.5 text-white/70">
+                {
+                  ANNOUNCEMENT_CATEGORIES.find((category) => category.value === formState.category)?.label ??
+                  formState.category
+                }
+              </span>
+            </div>
+            <h4 className="text-lg font-semibold text-white">{formState.title || '미리보기 제목'}</h4>
+            <p className="text-white/60">
+              {formState.content ? formState.content.slice(0, 160) : '공지 내용을 입력하면 여기에서 미리보기가 업데이트됩니다.'}
+              {formState.content.length > 160 ? '…' : ''}
+            </p>
+            <p className="text-xs text-white/40">{previewDate.toLocaleString('ko-KR')}</p>
+          </div>
+        </aside>
+      </form>
+    </div>
+  );
+}

--- a/app/admin/announcements/_components/announcement-list.tsx
+++ b/app/admin/announcements/_components/announcement-list.tsx
@@ -1,0 +1,247 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { ANNOUNCEMENT_CATEGORY_LABELS, type AnnouncementCategory } from '@/lib/constants/announcements';
+
+interface AdminAnnouncement {
+  id: string;
+  title: string;
+  content: string;
+  category: AnnouncementCategory | string;
+  isPinned: boolean;
+  publishedAt: string | null;
+  isNew: boolean;
+  updatedAt?: string;
+}
+
+async function fetchAdminAnnouncements() {
+  const response = await fetch('/api/announcements?includeScheduled=true');
+
+  if (!response.ok) {
+    throw new Error('공지 목록을 불러오지 못했습니다.');
+  }
+
+  const data = (await response.json()) as { announcements: AdminAnnouncement[] };
+  return data.announcements;
+}
+
+async function updateAnnouncementRequest(announcement: AdminAnnouncement & { publishedAtDraft?: string }) {
+  const response = await fetch(`/api/announcements/${announcement.id}`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      title: announcement.title,
+      content: announcement.content,
+      category: announcement.category,
+      isPinned: announcement.isPinned,
+      publishedAt: announcement.publishedAtDraft
+        ? new Date(announcement.publishedAtDraft).toISOString()
+        : announcement.publishedAt
+    })
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ message: '공지 업데이트에 실패했습니다.' }));
+    throw new Error(error.message ?? '공지 업데이트에 실패했습니다.');
+  }
+
+  return response.json();
+}
+
+async function deleteAnnouncementRequest(id: string) {
+  const response = await fetch(`/api/announcements/${id}`, {
+    method: 'DELETE'
+  });
+
+  if (!response.ok) {
+    throw new Error('공지를 삭제하지 못했습니다.');
+  }
+}
+
+const formatDate = (value: string | null) =>
+  value ? new Date(value).toLocaleString('ko-KR') : '발행 예정';
+
+export function AnnouncementList() {
+  const queryClient = useQueryClient();
+  const [scheduleDrafts, setScheduleDrafts] = useState<Record<string, string>>({});
+  const [error, setError] = useState<string | null>(null);
+
+  const { data: announcements = [], isLoading, isError } = useQuery({
+    queryKey: ['announcements', 'admin'],
+    queryFn: fetchAdminAnnouncements
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: updateAnnouncementRequest,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['announcements', 'admin'] });
+      queryClient.invalidateQueries({ queryKey: ['announcements'] });
+      setError(null);
+    },
+    onError: (mutationError) => {
+      if (mutationError instanceof Error) {
+        setError(mutationError.message);
+      } else {
+        setError('공지 업데이트 중 오류가 발생했습니다.');
+      }
+    }
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: deleteAnnouncementRequest,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['announcements', 'admin'] });
+      queryClient.invalidateQueries({ queryKey: ['announcements'] });
+    },
+    onError: (mutationError) => {
+      if (mutationError instanceof Error) {
+        setError(mutationError.message);
+      } else {
+        setError('공지 삭제 중 오류가 발생했습니다.');
+      }
+    }
+  });
+
+  const sortedAnnouncements = useMemo(() => {
+    return [...announcements].sort((a, b) => {
+      if (a.isPinned !== b.isPinned) {
+        return a.isPinned ? -1 : 1;
+      }
+
+      const dateA = a.publishedAt ? new Date(a.publishedAt).getTime() : 0;
+      const dateB = b.publishedAt ? new Date(b.publishedAt).getTime() : 0;
+      return dateB - dateA;
+    });
+  }, [announcements]);
+
+  const handleScheduleDraftChange = (id: string, value: string) => {
+    setScheduleDrafts((prev) => ({
+      ...prev,
+      [id]: value
+    }));
+  };
+
+  const handleSaveSchedule = (announcement: AdminAnnouncement) => {
+    const draft = scheduleDrafts[announcement.id];
+    updateMutation.mutate({ ...announcement, publishedAtDraft: draft });
+  };
+
+  const handleTogglePin = (announcement: AdminAnnouncement) => {
+    updateMutation.mutate({ ...announcement, isPinned: !announcement.isPinned });
+  };
+
+  const handleDelete = (announcement: AdminAnnouncement) => {
+    if (!window.confirm('이 공지를 삭제하시겠습니까? 삭제 후에는 되돌릴 수 없습니다.')) {
+      return;
+    }
+
+    deleteMutation.mutate(announcement.id);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="rounded-3xl border border-white/10 bg-white/[0.02] p-10 text-center text-sm text-white/60">
+        공지 데이터를 불러오는 중입니다…
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="rounded-3xl border border-rose-500/20 bg-rose-500/5 p-10 text-center text-sm text-rose-200">
+        공지 데이터를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-3xl border border-white/10 bg-white/[0.02] p-8">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <h2 className="text-xl font-semibold text-white">발행된 공지 관리</h2>
+          <p className="text-sm text-white/60">상단 고정 여부와 발행 일정을 조정하고 필요 시 공지를 삭제할 수 있습니다.</p>
+        </div>
+        <span className="rounded-full bg-white/5 px-3 py-1 text-xs text-white/70">총 {sortedAnnouncements.length}건</span>
+      </div>
+
+      {error ? <p className="mt-4 text-sm text-rose-300">{error}</p> : null}
+
+      <div className="mt-6 space-y-4">
+        {sortedAnnouncements.map((announcement) => {
+          const draftValue = scheduleDrafts[announcement.id] ??
+            (announcement.publishedAt ? new Date(announcement.publishedAt).toISOString().slice(0, 16) : '');
+          const categoryLabel =
+            ANNOUNCEMENT_CATEGORY_LABELS[announcement.category as AnnouncementCategory] ?? announcement.category;
+
+          return (
+            <div
+              key={announcement.id}
+              className="rounded-2xl border border-white/10 bg-white/[0.03] p-6 shadow-sm shadow-blue-500/5"
+            >
+              <div className="flex flex-wrap items-start justify-between gap-4">
+                <div className="space-y-2">
+                  <div className="flex flex-wrap items-center gap-2 text-xs text-white/50">
+                    {announcement.isPinned ? (
+                      <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-2 py-0.5 text-amber-300">
+                        📌 상단 고정
+                      </span>
+                    ) : null}
+                    <span className="inline-flex items-center gap-1 rounded-full bg-white/5 px-2 py-0.5 text-white/70">
+                      {categoryLabel}
+                    </span>
+                    <span>{formatDate(announcement.publishedAt)}</span>
+                  </div>
+                  <h3 className="text-lg font-semibold text-white">{announcement.title}</h3>
+                  <p className="line-clamp-2 text-sm text-white/60">{announcement.content}</p>
+                </div>
+
+                <div className="flex flex-col items-stretch gap-2 text-sm">
+                  <label className="text-xs text-white/60" htmlFor={`schedule-${announcement.id}`}>
+                    발행 시각 재설정
+                  </label>
+                  <input
+                    id={`schedule-${announcement.id}`}
+                    type="datetime-local"
+                    value={draftValue}
+                    onChange={(event) => handleScheduleDraftChange(announcement.id, event.target.value)}
+                    className="w-56 rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2 text-sm text-white focus:border-blue-400 focus:outline-none"
+                  />
+                  <div className="flex flex-col gap-2">
+                    <button
+                      type="button"
+                      onClick={() => handleSaveSchedule(announcement)}
+                      disabled={updateMutation.isPending}
+                      className="rounded-lg bg-blue-500 px-3 py-2 text-sm font-medium text-white transition hover:bg-blue-400 disabled:cursor-not-allowed disabled:bg-blue-500/50"
+                    >
+                      예약 저장
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleTogglePin(announcement)}
+                      disabled={updateMutation.isPending}
+                      className="rounded-lg border border-white/20 px-3 py-2 text-sm font-medium text-white transition hover:border-blue-400 hover:text-blue-200 disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      {announcement.isPinned ? '상단 고정 해제' : '상단에 고정'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(announcement)}
+                      disabled={deleteMutation.isPending}
+                      className="rounded-lg border border-rose-500/40 px-3 py-2 text-sm font-medium text-rose-200 transition hover:border-rose-400 hover:text-rose-100 disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      삭제
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/app/admin/announcements/page.tsx
+++ b/app/admin/announcements/page.tsx
@@ -1,0 +1,24 @@
+import { AnnouncementComposer } from './_components/announcement-composer';
+import { AnnouncementList } from './_components/announcement-list';
+
+export default function AdminAnnouncementsPage() {
+  return (
+    <div className="space-y-10 py-12">
+      <section className="space-y-6">
+        <div>
+          <p className="text-xs uppercase tracking-[0.3em] text-blue-300/80">Announcements</p>
+          <h1 className="mt-2 text-3xl font-semibold text-white">공지 관리</h1>
+          <p className="mt-2 max-w-2xl text-sm text-white/70">
+            플랫폼 전체 사용자에게 전달되는 공지를 작성하고 발행 일정을 관리하세요. 공지 등록과 동시에
+            알림이 발송되며, 상단 고정 및 예약 발행을 통해 중요도를 조정할 수 있습니다.
+          </p>
+        </div>
+        <AnnouncementComposer />
+      </section>
+
+      <section>
+        <AnnouncementList />
+      </section>
+    </div>
+  );
+}

--- a/app/announcements/[id]/page.tsx
+++ b/app/announcements/[id]/page.tsx
@@ -1,0 +1,85 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+
+import {
+  ANNOUNCEMENT_CATEGORY_LABELS,
+  type AnnouncementCategory
+} from '@/lib/constants/announcements';
+import { getServerAuthSession } from '@/lib/auth/session';
+import { getAnnouncementDetail } from '@/lib/server/announcements';
+import { UserRole } from '@/types/prisma';
+
+import { AnnouncementReadTracker } from './read-tracker';
+
+const DATE_FORMATTER = new Intl.DateTimeFormat('ko-KR', {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit'
+});
+
+const getCategoryLabel = (category: string) =>
+  ANNOUNCEMENT_CATEGORY_LABELS[category as AnnouncementCategory] ?? category;
+
+const formatDate = (date: Date | null) =>
+  date ? DATE_FORMATTER.format(typeof date === 'string' ? new Date(date) : date) : '발행 예정';
+
+export default async function AnnouncementDetailPage({
+  params
+}: {
+  params: { id: string };
+}) {
+  const session = await getServerAuthSession();
+  const announcement = await getAnnouncementDetail(params.id, session?.user?.id ?? null);
+
+  if (!announcement) {
+    notFound();
+  }
+
+  const publishedAt = announcement.publishedAt ?? announcement.updatedAt;
+  const isPublished = !announcement.publishedAt || new Date(announcement.publishedAt) <= new Date();
+  const isAdmin = session?.user?.role === UserRole.ADMIN;
+
+  if (!isPublished && !isAdmin) {
+    notFound();
+  }
+
+  const categoryLabel = getCategoryLabel(announcement.category);
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 pb-24">
+      <AnnouncementReadTracker
+        announcementId={announcement.id}
+        canAcknowledge={Boolean(session?.user)}
+        isAlreadyRead={announcement.isRead}
+      />
+      <header className="space-y-3 py-10">
+        <Link href="/announcements" className="text-sm text-blue-300 hover:text-blue-200">
+          ← 공지 목록으로 돌아가기
+        </Link>
+        <div className="flex flex-wrap items-center gap-3 text-xs text-white/60">
+          {announcement.isPinned ? (
+            <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-2 py-0.5 text-amber-300">
+              📌 상단 고정
+            </span>
+          ) : null}
+          <span className="inline-flex items-center gap-1 rounded-full bg-white/5 px-2 py-0.5 text-white/70">
+            {categoryLabel}
+          </span>
+          <span>{formatDate(publishedAt)}</span>
+          <span className="text-white/50">작성자 {announcement.author.name ?? '관리자'}</span>
+        </div>
+        <h1 className="text-4xl font-semibold text-white">{announcement.title}</h1>
+      </header>
+
+      <article className="prose prose-invert max-w-none space-y-6 text-base leading-relaxed">
+        {announcement.content.split('\n').map((paragraph, index) => (
+          <p key={index} className="text-white/80">
+            {paragraph.trim().length > 0 ? paragraph : '\u00A0'}
+          </p>
+        ))}
+      </article>
+    </div>
+  );
+}

--- a/app/announcements/[id]/read-tracker.tsx
+++ b/app/announcements/[id]/read-tracker.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+import { useMarkAnnouncementRead } from '@/hooks/use-announcement-read';
+
+interface AnnouncementReadTrackerProps {
+  announcementId: string;
+  canAcknowledge: boolean;
+  isAlreadyRead: boolean;
+}
+
+export function AnnouncementReadTracker({
+  announcementId,
+  canAcknowledge,
+  isAlreadyRead
+}: AnnouncementReadTrackerProps) {
+  const hasAcknowledgedRef = useRef(false);
+  const { mutate } = useMarkAnnouncementRead();
+
+  useEffect(() => {
+    if (!canAcknowledge || isAlreadyRead || hasAcknowledgedRef.current) {
+      return;
+    }
+
+    hasAcknowledgedRef.current = true;
+    mutate(announcementId);
+  }, [announcementId, canAcknowledge, isAlreadyRead, mutate]);
+
+  return null;
+}

--- a/app/announcements/page.tsx
+++ b/app/announcements/page.tsx
@@ -1,0 +1,125 @@
+import Link from 'next/link';
+
+import {
+  ANNOUNCEMENT_CATEGORIES,
+  ANNOUNCEMENT_CATEGORY_LABELS,
+  type AnnouncementCategory
+} from '@/lib/constants/announcements';
+import { getServerAuthSession } from '@/lib/auth/session';
+import { getAnnouncements } from '@/lib/server/announcements';
+
+const DATE_FORMATTER = new Intl.DateTimeFormat('ko-KR', {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit'
+});
+
+const FILTERS = [{ value: 'all', label: '전체' }, ...ANNOUNCEMENT_CATEGORIES];
+
+const getCategoryLabel = (category: string) =>
+  ANNOUNCEMENT_CATEGORY_LABELS[category as AnnouncementCategory] ?? category;
+
+const formatDate = (date: Date | null) =>
+  date ? DATE_FORMATTER.format(typeof date === 'string' ? new Date(date) : date) : '발행 예정';
+
+export default async function AnnouncementsPage({
+  searchParams
+}: {
+  searchParams?: { category?: string };
+}) {
+  const selectedCategory =
+    typeof searchParams?.category === 'string' ? searchParams.category : 'all';
+
+  const session = await getServerAuthSession();
+  const { announcements, unreadCount } = await getAnnouncements({
+    userId: session?.user?.id ?? null,
+    category: selectedCategory === 'all' ? null : selectedCategory
+  });
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 pb-16">
+      <header className="flex flex-col gap-3 py-12">
+        <div className="flex items-center gap-2 text-sm text-blue-300/80">
+          <span className="rounded-full bg-blue-500/10 px-3 py-1 text-xs font-semibold text-blue-300">
+            공지
+          </span>
+          {unreadCount > 0 ? <span>읽지 않은 공지 {unreadCount}건</span> : <span>모든 소식을 확인해보세요</span>}
+        </div>
+        <h1 className="text-3xl font-semibold text-white">플랫폼 공지사항</h1>
+        <p className="text-sm text-neutral-300">
+          Collaborium 팀의 최신 소식, 정책 변경, 이벤트 정보를 가장 먼저 확인하세요.
+        </p>
+      </header>
+
+      <section className="mb-10 flex flex-wrap gap-3">
+        {FILTERS.map((filter) => {
+          const isActive = selectedCategory === filter.value;
+          return (
+            <Link
+              key={filter.value}
+              href={filter.value === 'all' ? '/announcements' : `/announcements?category=${filter.value}`}
+              className={`rounded-full border px-4 py-2 text-sm transition-colors ${
+                isActive
+                  ? 'border-blue-400 bg-blue-500/10 text-blue-200'
+                  : 'border-white/10 bg-white/[0.04] text-white/70 hover:border-white/20 hover:text-white'
+              }`}
+            >
+              {filter.label}
+            </Link>
+          );
+        })}
+      </section>
+
+      <section>
+        {announcements.length === 0 ? (
+          <div className="rounded-2xl border border-dashed border-white/10 bg-white/[0.02] p-12 text-center text-sm text-white/60">
+            아직 공개된 공지가 없어요. 곧 새로운 소식을 전해드릴게요.
+          </div>
+        ) : (
+          <ul className="space-y-4">
+            {announcements.map((announcement) => {
+              const categoryLabel = getCategoryLabel(announcement.category);
+              const publishedLabel = formatDate(announcement.publishedAt);
+
+              return (
+                <li key={announcement.id} className="group rounded-2xl border border-white/10 bg-white/[0.03] p-6 transition hover:border-blue-400/60 hover:bg-white/[0.05]">
+                  <Link href={`/announcements/${announcement.id}`} className="block">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="space-y-2">
+                        <div className="flex items-center gap-2 text-xs text-white/60">
+                          {announcement.isPinned ? (
+                            <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-2 py-0.5 text-amber-300">
+                              📌 상단 고정
+                            </span>
+                          ) : null}
+                          <span className="inline-flex items-center gap-1 rounded-full bg-white/5 px-2 py-0.5 text-white/70">
+                            {categoryLabel}
+                          </span>
+                          <span>{publishedLabel}</span>
+                        </div>
+                        <h2 className="text-xl font-semibold text-white group-hover:text-blue-200">
+                          {announcement.title}
+                        </h2>
+                        <p className="line-clamp-2 text-sm leading-relaxed text-white/70">
+                          {announcement.content.replace(/\n+/g, ' ').slice(0, 160)}
+                          {announcement.content.length > 160 ? '…' : ''}
+                        </p>
+                      </div>
+                      {announcement.isNew ? (
+                        <span className="rounded-full bg-blue-500/20 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-blue-200">
+                          NEW
+                        </span>
+                      ) : null}
+                    </div>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/app/api/announcements/[id]/route.ts
+++ b/app/api/announcements/[id]/route.ts
@@ -1,0 +1,118 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { handleAuthorizationError, requireApiUser } from '@/lib/auth/guards';
+import { getServerAuthSession } from '@/lib/auth/session';
+import {
+  deleteAnnouncement,
+  getAnnouncementDetail,
+  markAnnouncementAsRead,
+  updateAnnouncement
+} from '@/lib/server/announcements';
+import { UserRole } from '@/types/prisma';
+
+export async function GET(_request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const session = await getServerAuthSession();
+    const userId = session?.user?.id ?? null;
+    const announcement = await getAnnouncementDetail(params.id, userId);
+
+    if (!announcement) {
+      return NextResponse.json({ message: '존재하지 않는 공지입니다.' }, { status: 404 });
+    }
+
+    return NextResponse.json(announcement);
+  } catch (error) {
+    console.error('Failed to load announcement', error);
+    return NextResponse.json({ message: 'Internal Server Error' }, { status: 500 });
+  }
+}
+
+export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
+  const body = await request.json();
+
+  if (body?.markAsRead) {
+    let user;
+
+    try {
+      user = await requireApiUser({});
+    } catch (error) {
+      const response = handleAuthorizationError(error);
+
+      if (response) {
+        return response;
+      }
+
+      throw error;
+    }
+
+    try {
+      await markAnnouncementAsRead(params.id, user.id);
+      const announcement = await getAnnouncementDetail(params.id, user.id);
+
+      return NextResponse.json({ status: 'ok', announcement });
+    } catch (error) {
+      console.error('Failed to mark announcement as read', error);
+      return NextResponse.json({ message: 'Internal Server Error' }, { status: 500 });
+    }
+  }
+
+  try {
+    await requireApiUser({ roles: [UserRole.ADMIN] });
+  } catch (error) {
+    const response = handleAuthorizationError(error);
+
+    if (response) {
+      return response;
+    }
+
+    throw error;
+  }
+
+  try {
+    if (!body?.title || !body?.content) {
+      return NextResponse.json(
+        { message: '제목과 내용을 모두 입력해 주세요.' },
+        { status: 400 }
+      );
+    }
+
+    const announcement = await updateAnnouncement(params.id, {
+      title: body.title,
+      content: body.content,
+      category: body.category,
+      isPinned: Boolean(body.isPinned),
+      publishedAt: body.publishedAt
+    });
+
+    if (!announcement) {
+      return NextResponse.json({ message: '존재하지 않는 공지입니다.' }, { status: 404 });
+    }
+
+    return NextResponse.json(announcement);
+  } catch (error) {
+    console.error('Failed to update announcement', error);
+    return NextResponse.json({ message: 'Internal Server Error' }, { status: 500 });
+  }
+}
+
+export async function DELETE(_request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    await requireApiUser({ roles: [UserRole.ADMIN] });
+  } catch (error) {
+    const response = handleAuthorizationError(error);
+
+    if (response) {
+      return response;
+    }
+
+    throw error;
+  }
+
+  try {
+    await deleteAnnouncement(params.id);
+    return new NextResponse(null, { status: 204 });
+  } catch (error) {
+    console.error('Failed to delete announcement', error);
+    return NextResponse.json({ message: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/app/api/announcements/route.ts
+++ b/app/api/announcements/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { handleAuthorizationError, requireApiUser } from '@/lib/auth/guards';
+import { getServerAuthSession } from '@/lib/auth/session';
+import { getAnnouncements, createAnnouncement } from '@/lib/server/announcements';
+import { UserRole } from '@/types/prisma';
+
+const parseCategory = (value: string | null): string | null => {
+  if (!value) {
+    return null;
+  }
+
+  return value;
+};
+
+export async function GET(request: NextRequest) {
+  const url = new URL(request.url);
+  const category = parseCategory(url.searchParams.get('category'));
+  const includeScheduled = url.searchParams.get('includeScheduled') === 'true';
+  const meta = url.searchParams.get('meta');
+
+  try {
+    const session = await getServerAuthSession();
+    const userId = session?.user?.id ?? null;
+    const userRole = session?.user?.role ?? null;
+
+    const { announcements, unreadCount } = await getAnnouncements({
+      userId,
+      category,
+      includeScheduled: includeScheduled && userRole === UserRole.ADMIN
+    });
+
+    if (meta === 'unread-count') {
+      return NextResponse.json({ unreadCount });
+    }
+
+    return NextResponse.json({ announcements, unreadCount });
+  } catch (error) {
+    console.error('Failed to load announcements', error);
+    return NextResponse.json({ message: 'Internal Server Error' }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  let admin;
+
+  try {
+    admin = await requireApiUser({ roles: [UserRole.ADMIN] });
+  } catch (error) {
+    const response = handleAuthorizationError(error);
+
+    if (response) {
+      return response;
+    }
+
+    throw error;
+  }
+
+  try {
+    const payload = await request.json();
+
+    if (!payload?.title || !payload?.content) {
+      return NextResponse.json(
+        { message: '제목과 내용을 모두 입력해 주세요.' },
+        { status: 400 }
+      );
+    }
+
+    const announcement = await createAnnouncement(
+      {
+        title: payload.title,
+        content: payload.content,
+        category: payload.category,
+        isPinned: Boolean(payload.isPinned),
+        publishedAt: payload.publishedAt
+      },
+      admin.id
+    );
+
+    return NextResponse.json(announcement, { status: 201 });
+  } catch (error) {
+    console.error('Failed to create announcement', error);
+    return NextResponse.json({ message: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/components/ui/layout/header.tsx
+++ b/components/ui/layout/header.tsx
@@ -4,14 +4,17 @@ import Link from 'next/link';
 import { useSession } from 'next-auth/react';
 
 import { canAccessRoute } from '@/lib/auth/role-guards';
+import { useAnnouncementUnreadCount } from '@/hooks/use-announcement-read';
 
 export function Header() {
   const { data: session } = useSession();
+  const { data: unreadCount = 0 } = useAnnouncementUnreadCount(Boolean(session?.user));
 
   const navigationItems = [
     { href: '/projects', label: '프로젝트' },
     { href: '/partners', label: '파트너' },
-    { href: '/community', label: '커뮤니티' }
+    { href: '/community', label: '커뮤니티' },
+    { href: '/announcements', label: '공지사항', unreadCount }
   ];
 
   if (session?.user && canAccessRoute(session.user, '/admin')) {
@@ -27,11 +30,24 @@ export function Header() {
           </Link>
 
           <nav className="hidden md:flex items-center space-x-8">
-            {navigationItems.map((item) => (
-              <Link key={item.href} href={item.href} className="hover:text-neutral-300 transition-colors">
-                {item.label}
-              </Link>
-            ))}
+            {navigationItems.map((item) => {
+              const showBadge = typeof item.unreadCount === 'number' && item.unreadCount > 0;
+
+              return (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className="relative hover:text-neutral-300 transition-colors"
+                >
+                  {item.label}
+                  {showBadge ? (
+                    <span className="absolute -right-3 -top-2 rounded-full bg-blue-500 px-1.5 py-0.5 text-[10px] font-semibold text-white">
+                      {item.unreadCount}
+                    </span>
+                  ) : null}
+                </Link>
+              );
+            })}
           </nav>
 
           <div className="flex items-center space-x-4">

--- a/components/ui/layout/mobile-tab-bar.tsx
+++ b/components/ui/layout/mobile-tab-bar.tsx
@@ -5,6 +5,7 @@ import { usePathname } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 
 import { canAccessRoute } from '@/lib/auth/role-guards';
+import { useAnnouncementUnreadCount } from '@/hooks/use-announcement-read';
 
 const baseTabs = [
   { href: '/', label: '홈', icon: '🏠' },
@@ -16,8 +17,10 @@ const baseTabs = [
 export function MobileTabBar() {
   const pathname = usePathname();
   const { data: session } = useSession();
+  const { data: unreadCount = 0 } = useAnnouncementUnreadCount(Boolean(session?.user));
 
   const tabs = [...baseTabs];
+  tabs.splice(3, 0, { href: '/announcements', label: '공지', icon: '📢', unreadCount });
 
   if (session?.user && canAccessRoute(session.user, '/admin')) {
     tabs.push({ href: '/admin', label: '관리', icon: '🛠️' });
@@ -38,12 +41,15 @@ export function MobileTabBar() {
               key={tab.href}
               href={tab.href}
               className={[
-                'flex flex-col items-center justify-center space-y-1 transition-colors',
+                'relative flex flex-col items-center justify-center space-y-1 transition-colors',
                 isActive ? 'text-blue-400' : 'text-neutral-400 hover:text-neutral-300'
               ].join(' ')}
             >
               <span className="text-lg">{tab.icon}</span>
               <span className="text-xs font-medium">{tab.label}</span>
+              {typeof tab.unreadCount === 'number' && tab.unreadCount > 0 ? (
+                <span className="absolute right-6 top-3 h-2.5 w-2.5 rounded-full bg-blue-500" aria-hidden="true" />
+              ) : null}
             </Link>
           );
         })}

--- a/hooks/use-announcement-read.ts
+++ b/hooks/use-announcement-read.ts
@@ -1,0 +1,58 @@
+'use client';
+
+import { useMutation, useQueryClient, useQuery } from '@tanstack/react-query';
+
+interface MarkReadResponse {
+  status: 'ok';
+  announcement?: unknown;
+}
+
+async function markAnnouncementReadRequest(announcementId: string) {
+  const response = await fetch(`/api/announcements/${announcementId}`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ markAsRead: true })
+  });
+
+  if (!response.ok) {
+    throw new Error('공지 읽음 처리에 실패했습니다.');
+  }
+
+  return (await response.json()) as MarkReadResponse;
+}
+
+async function fetchUnreadCount() {
+  const response = await fetch('/api/announcements?meta=unread-count');
+
+  if (!response.ok) {
+    throw new Error('공지 읽지 않음 수를 불러오지 못했습니다.');
+  }
+
+  const data = (await response.json()) as { unreadCount: number };
+  return data.unreadCount;
+}
+
+export function useMarkAnnouncementRead() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: ['announcements', 'mark-read'],
+    mutationFn: markAnnouncementReadRequest,
+    onSuccess: (_data, announcementId) => {
+      queryClient.invalidateQueries({ queryKey: ['announcements'] });
+      queryClient.invalidateQueries({ queryKey: ['announcements', 'detail', announcementId] });
+      queryClient.invalidateQueries({ queryKey: ['announcements', 'unread-count'] });
+    }
+  });
+}
+
+export function useAnnouncementUnreadCount(enabled: boolean) {
+  return useQuery({
+    queryKey: ['announcements', 'unread-count'],
+    queryFn: fetchUnreadCount,
+    staleTime: 1000 * 60,
+    enabled
+  });
+}

--- a/lib/constants/announcements.ts
+++ b/lib/constants/announcements.ts
@@ -1,0 +1,19 @@
+export const ANNOUNCEMENT_CATEGORIES = [
+  { value: 'platform', label: '플랫폼 업데이트' },
+  { value: 'policy', label: '정책 및 이용 안내' },
+  { value: 'event', label: '이벤트 소식' },
+  { value: 'maintenance', label: '서비스 점검' }
+] as const;
+
+export type AnnouncementCategory = (typeof ANNOUNCEMENT_CATEGORIES)[number]['value'];
+
+export const ANNOUNCEMENT_CATEGORY_LABELS: Record<AnnouncementCategory, string> =
+  ANNOUNCEMENT_CATEGORIES.reduce(
+    (labels, category) => ({
+      ...labels,
+      [category.value]: category.label
+    }),
+    {} as Record<AnnouncementCategory, string>
+  );
+
+export const DEFAULT_ANNOUNCEMENT_CATEGORY: AnnouncementCategory = 'platform';

--- a/lib/server/announcements.ts
+++ b/lib/server/announcements.ts
@@ -1,0 +1,313 @@
+import { NotificationType, Prisma } from '@prisma/client';
+
+import {
+  ANNOUNCEMENT_CATEGORY_LABELS,
+  DEFAULT_ANNOUNCEMENT_CATEGORY,
+  type AnnouncementCategory
+} from '@/lib/constants/announcements';
+import { prisma } from '@/lib/prisma';
+
+export interface AnnouncementListItem {
+  id: string;
+  title: string;
+  content: string;
+  category: AnnouncementCategory | string;
+  isPinned: boolean;
+  publishedAt: Date | null;
+  author: {
+    id: string;
+    name: string | null;
+    avatarUrl: string | null;
+  };
+  isRead: boolean;
+  isNew: boolean;
+}
+
+export interface AnnouncementDetail extends AnnouncementListItem {
+  updatedAt: Date;
+}
+
+const mapAnnouncement = (
+  announcement: Prisma.AnnouncementGetPayload<{
+    include: {
+      author: true;
+      reads: { select: { userId: true } };
+    };
+  }>,
+  userId?: string | null,
+  referenceDate: Date = new Date()
+): AnnouncementListItem => {
+  const hasRead = userId ? announcement.reads.some((read) => read.userId === userId) : false;
+  const publishedAt = announcement.publishedAt ?? announcement.createdAt;
+  const isPublished = !announcement.publishedAt || announcement.publishedAt <= referenceDate;
+  const rawCategory = announcement.category as AnnouncementCategory;
+  const category = Object.prototype.hasOwnProperty.call(
+    ANNOUNCEMENT_CATEGORY_LABELS,
+    rawCategory
+  )
+    ? rawCategory
+    : announcement.category;
+
+  return {
+    id: announcement.id,
+    title: announcement.title,
+    content: announcement.content,
+    category,
+    isPinned: announcement.isPinned,
+    publishedAt,
+    author: {
+      id: announcement.author.id,
+      name: announcement.author.name,
+      avatarUrl: announcement.author.avatarUrl
+    },
+    isRead: hasRead,
+    isNew: isPublished && !hasRead
+  };
+};
+
+export async function getAnnouncements(params: {
+  userId?: string | null;
+  category?: string | null;
+  includeScheduled?: boolean;
+}): Promise<{ announcements: AnnouncementListItem[]; unreadCount: number }>
+export async function getAnnouncements({
+  userId,
+  category,
+  includeScheduled = false
+}: {
+  userId?: string | null;
+  category?: string | null;
+  includeScheduled?: boolean;
+}): Promise<{ announcements: AnnouncementListItem[]; unreadCount: number }> {
+  const now = new Date();
+  const where: Prisma.AnnouncementWhereInput = {};
+
+  if (!includeScheduled) {
+    where.OR = [{ publishedAt: null }, { publishedAt: { lte: now } }];
+  }
+
+  if (category && category !== 'all') {
+    where.category = category;
+  }
+
+  const announcements = await prisma.announcement.findMany({
+    where,
+    include: {
+      author: true,
+      reads: userId
+        ? {
+            where: { userId },
+            select: { userId: true }
+          }
+        : { select: { userId: true } }
+    },
+    orderBy: [
+      { isPinned: 'desc' },
+      { publishedAt: 'desc' },
+      { createdAt: 'desc' }
+    ]
+  });
+
+  const mapped = announcements.map((announcement) => mapAnnouncement(announcement, userId, now));
+
+  const unreadCount = userId
+    ? await prisma.announcement.count({
+        where: {
+          OR: [{ publishedAt: null }, { publishedAt: { lte: now } }],
+          reads: {
+            none: {
+              userId
+            }
+          }
+        }
+      })
+    : 0;
+
+  return {
+    announcements: mapped,
+    unreadCount
+  };
+}
+
+export async function getAnnouncementDetail(
+  id: string,
+  userId?: string | null
+): Promise<AnnouncementDetail | null> {
+  const announcement = await prisma.announcement.findUnique({
+    where: { id },
+    include: {
+      author: true,
+      reads: userId
+        ? {
+            where: { userId },
+            select: { userId: true }
+          }
+        : { select: { userId: true } }
+    }
+  });
+
+  if (!announcement) {
+    return null;
+  }
+
+  const mapped = mapAnnouncement(announcement, userId);
+
+  return {
+    ...mapped,
+    updatedAt: announcement.updatedAt
+  };
+}
+
+interface AnnouncementPayload {
+  title: string;
+  content: string;
+  category?: string;
+  isPinned?: boolean;
+  publishedAt?: string | Date | null;
+}
+
+const resolveCategory = (category?: string | null): AnnouncementCategory => {
+  if (!category) {
+    return DEFAULT_ANNOUNCEMENT_CATEGORY;
+  }
+
+  const candidate = category as AnnouncementCategory;
+  if (Object.prototype.hasOwnProperty.call(ANNOUNCEMENT_CATEGORY_LABELS, candidate)) {
+    return candidate;
+  }
+
+  return DEFAULT_ANNOUNCEMENT_CATEGORY;
+};
+
+const resolvePublishedAt = (publishedAt?: string | Date | null): Date => {
+  if (!publishedAt) {
+    return new Date();
+  }
+
+  if (publishedAt instanceof Date) {
+    return publishedAt;
+  }
+
+  return new Date(publishedAt);
+};
+
+export async function createAnnouncement(
+  payload: AnnouncementPayload,
+  authorId: string
+): Promise<AnnouncementDetail> {
+  const category = resolveCategory(payload.category);
+  const publishedAt = resolvePublishedAt(payload.publishedAt);
+
+  const announcement = await prisma.announcement.create({
+    data: {
+      title: payload.title,
+      content: payload.content,
+      category,
+      isPinned: payload.isPinned ?? false,
+      publishedAt,
+      authorId
+    },
+    include: {
+      author: true,
+      reads: { select: { userId: true } }
+    }
+  });
+
+  const recipients = await prisma.user.findMany({
+    where: { id: { not: authorId } },
+    select: { id: true }
+  });
+
+  if (recipients.length > 0) {
+    await prisma.notification.createMany({
+      data: recipients.map(({ id }) => ({
+        userId: id,
+        type: NotificationType.ANNOUNCEMENT,
+        payload: {
+          announcementId: announcement.id,
+          title: announcement.title
+        }
+      })),
+      skipDuplicates: true
+    });
+  }
+
+  const mapped = mapAnnouncement(announcement, authorId);
+
+  return {
+    ...mapped,
+    updatedAt: announcement.updatedAt
+  };
+}
+
+export async function updateAnnouncement(
+  id: string,
+  payload: AnnouncementPayload
+): Promise<AnnouncementDetail | null> {
+  const announcement = await prisma.announcement.update({
+    where: { id },
+    data: {
+      title: payload.title,
+      content: payload.content,
+      category: resolveCategory(payload.category),
+      isPinned: payload.isPinned ?? false,
+      publishedAt: resolvePublishedAt(payload.publishedAt)
+    },
+    include: {
+      author: true,
+      reads: { select: { userId: true } }
+    }
+  }).catch(() => null);
+
+  if (!announcement) {
+    return null;
+  }
+
+  const mapped = mapAnnouncement(announcement);
+  return {
+    ...mapped,
+    updatedAt: announcement.updatedAt
+  };
+}
+
+export async function deleteAnnouncement(id: string): Promise<void> {
+  await prisma.announcement.delete({ where: { id } });
+}
+
+export async function markAnnouncementAsRead(
+  id: string,
+  userId: string
+): Promise<void> {
+  await prisma.announcementRead.upsert({
+    where: {
+      announcementId_userId: {
+        announcementId: id,
+        userId
+      }
+    },
+    create: {
+      announcementId: id,
+      userId
+    },
+    update: {
+      readAt: new Date()
+    }
+  });
+}
+
+export async function getUnreadAnnouncementCount(userId: string): Promise<number> {
+  const now = new Date();
+
+  const count = await prisma.announcement.count({
+    where: {
+      OR: [{ publishedAt: null }, { publishedAt: { lte: now } }],
+      reads: {
+        none: {
+          userId
+        }
+      }
+    }
+  });
+
+  return count;
+}

--- a/prisma/migrations/20240226000000_add_announcements/migration.sql
+++ b/prisma/migrations/20240226000000_add_announcements/migration.sql
@@ -1,0 +1,42 @@
+-- AlterEnum
+ALTER TYPE "NotificationType" ADD VALUE IF NOT EXISTS 'ANNOUNCEMENT';
+
+-- CreateTable
+CREATE TABLE "Announcement" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "category" TEXT NOT NULL,
+    "isPinned" BOOLEAN NOT NULL DEFAULT false,
+    "publishedAt" TIMESTAMP(3),
+    "authorId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Announcement_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AnnouncementRead" (
+    "id" TEXT NOT NULL,
+    "announcementId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "readAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AnnouncementRead_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AnnouncementRead_announcementId_userId_key" ON "AnnouncementRead"("announcementId", "userId");
+
+-- AddForeignKey
+ALTER TABLE "Announcement"
+ADD CONSTRAINT "Announcement_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AnnouncementRead"
+ADD CONSTRAINT "AnnouncementRead_announcementId_fkey" FOREIGN KEY ("announcementId") REFERENCES "Announcement"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AnnouncementRead"
+ADD CONSTRAINT "AnnouncementRead_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -96,6 +96,7 @@ enum NotificationType {
   PARTNER_REQUEST
   SETTLEMENT_PAID
   SYSTEM
+  ANNOUNCEMENT
 }
 
 enum MilestoneStatus {
@@ -118,34 +119,36 @@ enum ModerationStatus {
 }
 
 model User {
-  id               String                @id @default(cuid())
-  name             String
-  email            String                @unique
-  role             UserRole              @default(PARTICIPANT)
-  passwordHash     String?
-  avatarUrl        String?
-  language         String                @default("ko")
-  timezone         String?
-  bio              String?
-  socialLinks      Json?
-  createdAt        DateTime              @default(now())
-  updatedAt        DateTime              @updatedAt
-  projects         Project[]             @relation("OwnerProjects")
-  collaborations   ProjectCollaborator[]
-  fundings         Funding[]
-  posts            Post[]
-  comments         Comment[]
-  postLikes        PostLike[]
-  commentReactions CommentReaction[]
-  notifications    Notification[]
-  partner          Partner?
-  orders           Order[]
-  wallet           Wallet?
-  auditLogs        AuditLog[]
-  permissions      UserPermission[]
-  following        UserFollow[]          @relation("UserFollowing")
-  followers        UserFollow[]          @relation("UserFollowers")
-  filedReports     ModerationReport[]    @relation("ModerationReportReporter")
+  id                String                @id @default(cuid())
+  name              String
+  email             String                @unique
+  role              UserRole              @default(PARTICIPANT)
+  passwordHash      String?
+  avatarUrl         String?
+  language          String                @default("ko")
+  timezone          String?
+  bio               String?
+  socialLinks       Json?
+  createdAt         DateTime              @default(now())
+  updatedAt         DateTime              @updatedAt
+  projects          Project[]             @relation("OwnerProjects")
+  collaborations    ProjectCollaborator[]
+  fundings          Funding[]
+  posts             Post[]
+  comments          Comment[]
+  postLikes         PostLike[]
+  commentReactions  CommentReaction[]
+  notifications     Notification[]
+  partner           Partner?
+  orders            Order[]
+  wallet            Wallet?
+  auditLogs         AuditLog[]
+  permissions       UserPermission[]
+  following         UserFollow[]          @relation("UserFollowing")
+  followers         UserFollow[]          @relation("UserFollowers")
+  filedReports      ModerationReport[]    @relation("ModerationReportReporter")
+  announcements     Announcement[]
+  announcementReads AnnouncementRead[]
 }
 
 model Project {
@@ -363,6 +366,31 @@ model Notification {
   payload   Json
   read      Boolean          @default(false)
   createdAt DateTime         @default(now())
+}
+
+model Announcement {
+  id          String             @id @default(cuid())
+  title       String
+  content     String
+  category    String
+  isPinned    Boolean            @default(false)
+  publishedAt DateTime?
+  author      User               @relation(fields: [authorId], references: [id])
+  authorId    String
+  reads       AnnouncementRead[]
+  createdAt   DateTime           @default(now())
+  updatedAt   DateTime           @updatedAt
+}
+
+model AnnouncementRead {
+  id             String       @id @default(cuid())
+  announcement   Announcement @relation(fields: [announcementId], references: [id], onDelete: Cascade)
+  announcementId String
+  user           User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId         String
+  readAt         DateTime     @default(now())
+
+  @@unique([announcementId, userId])
 }
 
 model Wallet {

--- a/tests/announcements-ui.test.tsx
+++ b/tests/announcements-ui.test.tsx
@@ -1,0 +1,89 @@
+import type { ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
+
+jest.mock('next/link', () => {
+  return ({ children, href }: { children: ReactNode; href: string }) => <a href={href}>{children}</a>;
+});
+
+jest.mock('@/lib/server/announcements', () => ({
+  getAnnouncements: jest.fn()
+}));
+
+jest.mock('@/lib/auth/session', () => ({
+  getServerAuthSession: jest.fn()
+}));
+
+jest.mock('@/hooks/use-announcement-read', () => ({
+  useMarkAnnouncementRead: jest.fn(() => ({ mutate: jest.fn() })),
+  useAnnouncementUnreadCount: jest.fn(() => ({ data: 0 }))
+}));
+
+import AnnouncementsPage from '@/app/announcements/page';
+import { AnnouncementReadTracker } from '@/app/announcements/[id]/read-tracker';
+
+const { getAnnouncements } = jest.requireMock('@/lib/server/announcements');
+const { getServerAuthSession } = jest.requireMock('@/lib/auth/session');
+const { useMarkAnnouncementRead } = jest.requireMock('@/hooks/use-announcement-read');
+
+describe('Announcements UI', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getServerAuthSession.mockResolvedValue({ user: { id: 'user-1' } });
+  });
+
+  it('renders pinned announcements with NEW badges', async () => {
+    getAnnouncements.mockResolvedValue({
+      announcements: [
+        {
+          id: 'announcement-1',
+          title: '중요 공지',
+          content: '테스트 본문',
+          category: 'platform',
+          isPinned: true,
+          publishedAt: new Date().toISOString(),
+          author: { id: 'admin-1', name: '관리자', avatarUrl: null },
+          isRead: false,
+          isNew: true
+        },
+        {
+          id: 'announcement-2',
+          title: '일반 공지',
+          content: '다른 공지',
+          category: 'event',
+          isPinned: false,
+          publishedAt: new Date().toISOString(),
+          author: { id: 'admin-1', name: '관리자', avatarUrl: null },
+          isRead: true,
+          isNew: false
+        }
+      ],
+      unreadCount: 1
+    });
+
+    const jsx = await AnnouncementsPage({ searchParams: {} });
+    const { container } = render(jsx);
+
+    const titles = Array.from(container.querySelectorAll('h2')).map((element) => element.textContent);
+    expect(titles[0]).toContain('중요 공지');
+
+    expect(screen.getByText('NEW')).toBeInTheDocument();
+  });
+
+  it('marks announcements as read when tracker runs', () => {
+    const mutate = jest.fn();
+    useMarkAnnouncementRead.mockReturnValueOnce({ mutate });
+
+    render(<AnnouncementReadTracker announcementId="announcement-1" canAcknowledge isAlreadyRead={false} />);
+
+    expect(mutate).toHaveBeenCalledWith('announcement-1');
+  });
+
+  it('does not mark announcements as read for guests', () => {
+    const mutate = jest.fn();
+    useMarkAnnouncementRead.mockReturnValueOnce({ mutate });
+
+    render(<AnnouncementReadTracker announcementId="announcement-1" canAcknowledge={false} isAlreadyRead={false} />);
+
+    expect(mutate).not.toHaveBeenCalled();
+  });
+});

--- a/types/prisma.ts
+++ b/types/prisma.ts
@@ -20,6 +20,8 @@ import {
 } from '@prisma/client';
 
 import type {
+  Announcement,
+  AnnouncementRead,
   User,
   Project,
   ProjectCollaborator,
@@ -53,6 +55,8 @@ export { PrismaClient, Prisma } from '@prisma/client';
 
 // 타입들은 별도로 export
 export type {
+  Announcement,
+  AnnouncementRead,
   User,
   Project,
   ProjectCollaborator,
@@ -235,5 +239,6 @@ export const NOTIFICATION_TYPE_LABELS: Record<NotificationType, string> = {
   [NotificationType.PROJECT_MILESTONE]: '프로젝트 마일스톤',
   [NotificationType.PARTNER_REQUEST]: '파트너 요청',
   [NotificationType.SETTLEMENT_PAID]: '정산 완료',
-  [NotificationType.SYSTEM]: '시스템 알림'
+  [NotificationType.SYSTEM]: '시스템 알림',
+  [NotificationType.ANNOUNCEMENT]: '공지 알림'
 };


### PR DESCRIPTION
## Summary
- introduce Announcement and AnnouncementRead Prisma models plus migrations and client updates
- implement announcements API endpoints, shared server logic, public views, and navigation unread badges with mark-as-read hook
- add admin announcement composer/manager UI and accompanying Jest integration and client tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d7fd9ee3f08326baca703b853769e9