### PR TITLE
Revamp community pulse spotlight on home page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -68,6 +68,7 @@ export default function HomePage() {
 
   const artists = artistsResponse?.artists ?? [];
   const communityPosts = communityResponse?.posts ?? [];
+  const [featuredPost, ...highlightedPosts] = communityPosts;
 
   const popularProjects = useMemo(() => {
     return [...projects].sort((a, b) => b.participants - a.participants).slice(0, 6);
@@ -255,38 +256,84 @@ export default function HomePage() {
           href="/community"
           ctaLabel={t('actions.viewMore') ?? undefined}
         />
-        <div className="mt-6 space-y-3">
-          {communityPosts.length === 0 ? (
-            <div className="rounded-3xl border border-dashed border-white/10 bg-white/5 p-10 text-center text-sm text-white/60">
-              {t('home.empty.community')}
-            </div>
-          ) : (
-            communityPosts.map((post) => (
+        {communityPosts.length === 0 ? (
+          <div className="mt-6 rounded-3xl border border-dashed border-white/10 bg-white/5 p-10 text-center text-sm text-white/60">
+            {t('home.empty.community')}
+          </div>
+        ) : (
+          <div className="mt-6 grid gap-4 lg:grid-cols-[1.4fr_1fr] xl:grid-cols-[3fr_2fr]">
+            {featuredPost ? (
               <Link
-                key={post.id}
-                href={`/community/${post.id}`}
-                className="flex flex-col gap-3 rounded-3xl border border-white/10 bg-white/5 p-5 transition hover:border-primary/40 hover:bg-white/10"
+                href={`/community/${featuredPost.id}`}
+                className="group flex h-full flex-col gap-6 rounded-3xl border border-white/10 bg-gradient-to-br from-white/10 via-white/5 to-white/[0.02] p-6 transition hover:border-primary/40 hover:from-primary/20 hover:via-primary/10 hover:to-primary/0"
               >
-                <div className="flex items-center gap-3 text-xs uppercase tracking-[0.3em] text-white/50">
+                <div className="flex flex-wrap items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.3em] text-white/60">
                   <span className="rounded-full bg-white/10 px-3 py-1 text-white">
-                    {t(`community.filters.${post.category}`)}
+                    {t(`community.filters.${featuredPost.category}`)}
                   </span>
-                  {post.isTrending ? (
+                  {featuredPost.isTrending ? (
                     <span className="rounded-full bg-primary/20 px-3 py-1 text-primary">
                       {t('community.badges.trending')}
                     </span>
                   ) : null}
                 </div>
-                <h3 className="text-lg font-semibold text-white">{post.title}</h3>
-                <p className="text-sm text-white/70 line-clamp-2">{post.content}</p>
-                <div className="flex items-center justify-between text-xs text-white/50">
-                  <span>{post.author?.name ?? t('community.defaultGuestName')}</span>
-                  <span>{t('community.likesLabel_other', { count: post.likes })}</span>
+                <div className="space-y-3">
+                  <h3 className="text-2xl font-semibold text-white group-hover:text-primary">
+                    {featuredPost.title}
+                  </h3>
+                  <p className="text-sm text-white/70 line-clamp-4">{featuredPost.content}</p>
+                </div>
+                <div className="flex flex-wrap items-center justify-between gap-3 text-xs text-white/60">
+                  <span>{featuredPost.author?.name ?? t('community.defaultGuestName')}</span>
+                  <div className="flex items-center gap-3">
+                    <span>{t('community.likesLabel_other', { count: featuredPost.likes ?? 0 })}</span>
+                    <span>{t('community.commentsLabel_other', { count: featuredPost.comments ?? 0 })}</span>
+                  </div>
                 </div>
               </Link>
-            ))
-          )}
-        </div>
+            ) : null}
+            <div className="flex flex-col gap-3 rounded-3xl border border-white/10 bg-white/5 p-5">
+              <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-[0.3em] text-white/50">
+                <span>{t('home.sections.communityPulse')}</span>
+                <Link href="/community" className="text-white/60 transition hover:text-white">
+                  {t('actions.viewMore')}
+                </Link>
+              </div>
+              <div className="grid gap-3 sm:grid-cols-2">
+                {highlightedPosts.length === 0 ? (
+                  <div className="col-span-full rounded-2xl border border-dashed border-white/10 bg-white/5 p-6 text-center text-xs text-white/50">
+                    {t('home.empty.community')}
+                  </div>
+                ) : (
+                  highlightedPosts.map((post) => (
+                    <Link
+                      key={post.id}
+                      href={`/community/${post.id}`}
+                      className="group flex flex-col gap-2 rounded-2xl border border-white/10 bg-neutral-950/60 px-4 py-3 transition hover:border-primary/40 hover:bg-neutral-900/80"
+                    >
+                      <div className="flex items-center justify-between text-[11px] uppercase tracking-[0.3em] text-white/50">
+                        <span className="truncate text-white/70">
+                          {t(`community.filters.${post.category}`)}
+                        </span>
+                        {post.isTrending ? (
+                          <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[10px] text-primary">
+                            {t('community.badges.trending')}
+                          </span>
+                        ) : null}
+                      </div>
+                      <p className="text-sm font-semibold text-white group-hover:text-primary line-clamp-2">{post.title}</p>
+                      <p className="text-xs text-white/60 line-clamp-2">{post.content}</p>
+                      <div className="mt-auto flex items-center justify-between text-[11px] text-white/50">
+                        <span className="truncate">{post.author?.name ?? t('community.defaultGuestName')}</span>
+                        <span>{t('community.likesLabel_other', { count: post.likes ?? 0 })}</span>
+                      </div>
+                    </Link>
+                  ))
+                )}
+              </div>
+            </div>
+          </div>
+        )}
       </section>
 
       <section>


### PR DESCRIPTION
## Summary
- spotlight the top community post in a featured card on the home page
- add a secondary grid to surface additional trending community updates
- show post metadata like author, likes, and comments within the pulse layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d8e24cf1fc8326ac75c3ab6a35f4c2