### PR TITLE
feat: implement token-based session management

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,0 +1,129 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { z } from 'zod';
+
+import { prisma } from '@/lib/prisma';
+import { buildRefreshCookie } from '@/lib/auth/cookies';
+import type { ClientKind } from '@/lib/auth/policy';
+import { issueSessionWithTokens } from '@/lib/auth/session-store';
+import { verifyPassword } from '@/lib/auth/password';
+import { UserRole } from '@/types/prisma';
+
+const requestSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(1),
+  rememberMe: z.boolean().optional(),
+  client: z.enum(['web', 'mobile']).optional(),
+  deviceFingerprint: z.string().min(8).max(256).optional(),
+  deviceLabel: z.string().max(120).optional()
+});
+
+const extractClientIp = (req: NextRequest) => {
+  const forwarded = req.headers.get('x-forwarded-for');
+
+  if (forwarded) {
+    const [first] = forwarded.split(',');
+    if (first) {
+      return first.trim();
+    }
+  }
+
+  const realIp = req.headers.get('x-real-ip');
+  if (realIp) {
+    return realIp;
+  }
+
+  return null;
+};
+
+export async function POST(req: NextRequest) {
+  let body: unknown;
+
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: '잘못된 요청 본문입니다.' }, { status: 400 });
+  }
+
+  const parsed = requestSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return NextResponse.json({ error: '요청 형식이 올바르지 않습니다.' }, { status: 400 });
+  }
+
+  const data = parsed.data;
+
+  const user = await prisma.user.findUnique({
+    where: { email: data.email },
+    include: {
+      permissions: {
+        include: {
+          permission: true
+        }
+      }
+    }
+  });
+
+  if (!user || !user.passwordHash) {
+    return NextResponse.json({ error: '아이디 또는 비밀번호가 올바르지 않습니다.' }, { status: 401 });
+  }
+
+  const passwordMatches = await verifyPassword(user.passwordHash, data.password);
+
+  if (!passwordMatches) {
+    return NextResponse.json({ error: '아이디 또는 비밀번호가 올바르지 않습니다.' }, { status: 401 });
+  }
+
+  const remember = user.role === UserRole.ADMIN ? false : data.rememberMe ?? false;
+  const client: ClientKind = data.client === 'mobile' ? 'mobile' : 'web';
+  const ipAddress = extractClientIp(req);
+  const userAgent = req.headers.get('user-agent');
+
+  try {
+    const issued = await issueSessionWithTokens({
+      userId: user.id,
+      role: user.role as UserRole,
+      remember,
+      client,
+      ipAddress,
+      userAgent,
+      deviceFingerprint: data.deviceFingerprint ?? null,
+      deviceLabel: data.deviceLabel ?? null
+    });
+
+    const refreshMaxAge = Math.max(
+      0,
+      Math.floor(
+        (issued.refreshRecord.inactivityExpiresAt.getTime() - Date.now()) / 1000
+      )
+    );
+
+    return NextResponse.json(
+      {
+        accessToken: issued.accessToken,
+        accessTokenExpiresAt: issued.accessTokenExpiresAt.toISOString(),
+        refreshTokenExpiresAt: issued.refreshRecord.inactivityExpiresAt.toISOString(),
+        session: {
+          id: issued.session.id,
+          absoluteExpiresAt: issued.session.absoluteExpiresAt.toISOString(),
+          lastUsedAt: issued.session.lastUsedAt.toISOString(),
+          remember: issued.session.remember,
+          client: issued.session.client
+        },
+        user: {
+          id: user.id,
+          role: user.role,
+          permissions: issued.permissions
+        }
+      },
+      {
+        status: 200,
+        headers: {
+          'Set-Cookie': buildRefreshCookie(issued.refreshToken, refreshMaxAge)
+        }
+      }
+    );
+  } catch (error) {
+    console.error('로그인 처리 중 오류 발생', error);
+    return NextResponse.json({ error: '로그인 처리에 실패했습니다.' }, { status: 500 });
+  }
+}

--- a/app/api/auth/logout-all/route.ts
+++ b/app/api/auth/logout-all/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse, type NextRequest } from 'next/server';
+
+import { verifyAccessToken } from '@/lib/auth/access-token';
+import { buildRefreshCookieRemoval } from '@/lib/auth/cookies';
+import { blacklistToken } from '@/lib/auth/token-blacklist';
+import { revokeAllSessionsForUser } from '@/lib/auth/session-store';
+
+export async function POST(req: NextRequest) {
+  const authorization = req.headers.get('authorization');
+
+  if (!authorization?.startsWith('Bearer ')) {
+    return NextResponse.json({ error: '인증 토큰이 필요합니다.' }, { status: 401 });
+  }
+
+  const token = authorization.slice(7).trim();
+
+  if (!token) {
+    return NextResponse.json({ error: '인증 토큰이 필요합니다.' }, { status: 401 });
+  }
+
+  try {
+    const verified = await verifyAccessToken(token);
+
+    await revokeAllSessionsForUser(verified.userId);
+    await blacklistToken(verified.jti, verified.expiresAt);
+
+    return NextResponse.json(
+      { success: true },
+      {
+        headers: {
+          'Set-Cookie': buildRefreshCookieRemoval()
+        }
+      }
+    );
+  } catch (error) {
+    console.error('전체 로그아웃 처리 실패', error);
+    return NextResponse.json({ error: '인증 토큰이 유효하지 않습니다.' }, { status: 401 });
+  }
+}

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse, type NextRequest } from 'next/server';
+
+import { verifyAccessToken } from '@/lib/auth/access-token';
+import { buildRefreshCookieRemoval, REFRESH_COOKIE } from '@/lib/auth/cookies';
+import { blacklistToken } from '@/lib/auth/token-blacklist';
+import { revokeSessionByRefreshToken } from '@/lib/auth/session-store';
+
+export async function POST(req: NextRequest) {
+  const refreshToken = req.cookies.get(REFRESH_COOKIE)?.value;
+
+  if (refreshToken) {
+    try {
+      await revokeSessionByRefreshToken(refreshToken);
+    } catch (error) {
+      console.warn('세션 폐기 중 오류', error);
+    }
+  }
+
+  const authorization = req.headers.get('authorization');
+
+  if (authorization?.startsWith('Bearer ')) {
+    const token = authorization.slice(7).trim();
+
+    if (token) {
+      try {
+        const verified = await verifyAccessToken(token);
+        await blacklistToken(verified.jti, verified.expiresAt);
+      } catch (error) {
+        console.warn('액세스 토큰 블랙리스트 처리 실패', error);
+      }
+    }
+  }
+
+  return NextResponse.json(
+    { success: true },
+    {
+      headers: {
+        'Set-Cookie': buildRefreshCookieRemoval()
+      }
+    }
+  );
+}

--- a/app/api/auth/refresh/route.ts
+++ b/app/api/auth/refresh/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse, type NextRequest } from 'next/server';
+
+import { buildRefreshCookie, buildRefreshCookieRemoval, REFRESH_COOKIE } from '@/lib/auth/cookies';
+import { rotateRefreshToken } from '@/lib/auth/session-store';
+
+const extractClientIp = (req: NextRequest) => {
+  const forwarded = req.headers.get('x-forwarded-for');
+
+  if (forwarded) {
+    const [first] = forwarded.split(',');
+    if (first) {
+      return first.trim();
+    }
+  }
+
+  const realIp = req.headers.get('x-real-ip');
+  if (realIp) {
+    return realIp;
+  }
+
+  return null;
+};
+
+export async function POST(req: NextRequest) {
+  const cookie = req.cookies.get(REFRESH_COOKIE)?.value;
+
+  if (!cookie) {
+    return NextResponse.json({ error: '리프레시 토큰이 필요합니다.' }, { status: 401 });
+  }
+
+  const ipAddress = extractClientIp(req);
+  const userAgent = req.headers.get('user-agent');
+
+  try {
+    const rotated = await rotateRefreshToken(cookie, { ipAddress, userAgent });
+
+    const refreshMaxAge = Math.max(
+      0,
+      Math.floor(
+        (rotated.refreshRecord.inactivityExpiresAt.getTime() - Date.now()) / 1000
+      )
+    );
+
+    return NextResponse.json(
+      {
+        accessToken: rotated.accessToken,
+        accessTokenExpiresAt: rotated.accessTokenExpiresAt.toISOString(),
+        refreshTokenExpiresAt: rotated.refreshRecord.inactivityExpiresAt.toISOString(),
+        session: {
+          id: rotated.session.id,
+          absoluteExpiresAt: rotated.session.absoluteExpiresAt.toISOString(),
+          lastUsedAt: rotated.session.lastUsedAt.toISOString(),
+          remember: rotated.session.remember,
+          client: rotated.session.client
+        }
+      },
+      {
+        status: 200,
+        headers: {
+          'Set-Cookie': buildRefreshCookie(rotated.refreshToken, refreshMaxAge)
+        }
+      }
+    );
+  } catch (error) {
+    console.error('리프레시 토큰 갱신 실패', error);
+    return NextResponse.json(
+      { error: '세션이 유효하지 않습니다. 다시 로그인하세요.' },
+      {
+        status: 401,
+        headers: {
+          'Set-Cookie': buildRefreshCookieRemoval()
+        }
+      }
+    );
+  }
+}

--- a/app/api/auth/sessions/route.ts
+++ b/app/api/auth/sessions/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse, type NextRequest } from 'next/server';
+
+import { verifyAccessToken } from '@/lib/auth/access-token';
+import { prisma } from '@/lib/prisma';
+
+export async function GET(req: NextRequest) {
+  const authorization = req.headers.get('authorization');
+
+  if (!authorization?.startsWith('Bearer ')) {
+    return NextResponse.json({ error: '인증 토큰이 필요합니다.' }, { status: 401 });
+  }
+
+  const token = authorization.slice(7).trim();
+
+  if (!token) {
+    return NextResponse.json({ error: '인증 토큰이 필요합니다.' }, { status: 401 });
+  }
+
+  try {
+    const verified = await verifyAccessToken(token);
+
+    const sessions = await prisma.authSession.findMany({
+      where: {
+        userId: verified.userId,
+        revokedAt: null
+      },
+      include: {
+        device: true
+      },
+      orderBy: {
+        lastUsedAt: 'desc'
+      }
+    });
+
+    return NextResponse.json({
+      sessions: sessions.map((session) => ({
+        id: session.id,
+        createdAt: session.createdAt.toISOString(),
+        lastUsedAt: session.lastUsedAt.toISOString(),
+        absoluteExpiresAt: session.absoluteExpiresAt.toISOString(),
+        remember: session.remember,
+        client: session.client,
+        ipHash: session.ipHash,
+        uaHash: session.uaHash,
+        isAdmin: session.isAdmin,
+        device: session.device
+          ? {
+              id: session.device.id,
+              label: session.device.label,
+              firstSeenAt: session.device.firstSeenAt.toISOString(),
+              lastSeenAt: session.device.lastSeenAt.toISOString()
+            }
+          : null,
+        current: session.id === verified.sessionId
+      }))
+    });
+  } catch (error) {
+    console.error('세션 조회 실패', error);
+    return NextResponse.json({ error: '인증 토큰이 유효하지 않습니다.' }, { status: 401 });
+  }
+}

--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -1,126 +1,147 @@
-﻿'use client';
+'use client';
 
 import { useState } from 'react';
 import { signIn, getSession } from 'next-auth/react';
-import { SESSION_PERSISTENCE_KEY, SESSION_PERSISTENCE_SEED } from '@/lib/auth/session-persistence';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 
+import { SESSION_PERSISTENCE_KEY, SESSION_PERSISTENCE_SEED } from '@/lib/auth/session-persistence';
+
 export default function SignInPage() {
-    const [email, setEmail] = useState('');
-    const [password, setPassword] = useState('');
-    const [isLoading, setIsLoading] = useState(false);
-    const [error, setError] = useState('');
-    const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [rememberMe, setRememberMe] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+  const router = useRouter();
 
-    const handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault();
-        setIsLoading(true);
-        setError('');
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setIsLoading(true);
+    setError('');
 
-        try {
-            const result = await signIn('credentials', {
-                email,
-                password,
-                redirect: false,
-            });
+    try {
+      const loginResponse = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        credentials: 'include',
+        body: JSON.stringify({
+          email,
+          password,
+          rememberMe,
+          client: 'web'
+        })
+      });
 
-            if (result?.error) {
-                setError('이메일 또는 비밀번호가 올바르지 않습니다.');
-            } else {
-                // 로그인 성공 시 이전 페이지로 리다이렉트
-                if (typeof window !== 'undefined') {
-                    window.sessionStorage.setItem(SESSION_PERSISTENCE_KEY, SESSION_PERSISTENCE_SEED);
-                }
+      if (!loginResponse.ok) {
+        const payload = await loginResponse.json().catch(() => ({ error: '로그인에 실패했습니다.' }));
+        setError(payload.error ?? '로그인에 실패했습니다.');
+        return;
+      }
 
-                const session = await getSession();
-                if (session) {
-                    router.push('/');
-                }
-            }
-        } catch {
-            setError('로그인 중 오류가 발생했습니다.');
-        } finally {
-            setIsLoading(false);
-        }
-    };
+      const result = await signIn('credentials', {
+        email,
+        password,
+        redirect: false
+      });
 
-    return (
-        <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-purple-900 via-blue-900 to-indigo-900">
-            <div className="max-w-md w-full space-y-8 p-8">
-                <div className="text-center">
-                    <h2 className="mt-6 text-3xl font-bold text-white">
-                        로그인
-                    </h2>
-                    <p className="mt-2 text-sm text-gray-300">
-                        아티스트 펀딩 협업 플랫폼에 오신 것을 환영합니다
-                    </p>
-                </div>
+      if (result?.error) {
+        setError('이메일 또는 비밀번호가 올바르지 않습니다.');
+        return;
+      }
 
-                <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
-                    <div className="space-y-4">
-                        <div>
-                            <label htmlFor="email" className="block text-sm font-medium text-gray-300">
-                                이메일
-                            </label>
-                            <input
-                                id="email"
-                                name="email"
-                                type="email"
-                                required
-                                value={email}
-                                onChange={(e) => setEmail(e.target.value)}
-                                className="mt-1 block w-full px-3 py-2 border border-gray-600 rounded-md shadow-sm bg-gray-800 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent"
-                                placeholder="이메일을 입력하세요"
-                            />
-                        </div>
+      if (typeof window !== 'undefined') {
+        window.sessionStorage.setItem(SESSION_PERSISTENCE_KEY, SESSION_PERSISTENCE_SEED);
+      }
 
-                        <div>
-                            <label htmlFor="password" className="block text-sm font-medium text-gray-300">
-                                비밀번호
-                            </label>
-                            <input
-                                id="password"
-                                name="password"
-                                type="password"
-                                required
-                                value={password}
-                                onChange={(e) => setPassword(e.target.value)}
-                                className="mt-1 block w-full px-3 py-2 border border-gray-600 rounded-md shadow-sm bg-gray-800 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent"
-                                placeholder="비밀번호를 입력하세요"
-                            />
-                        </div>
-                    </div>
+      const session = await getSession();
+      if (session) {
+        router.push('/');
+      }
+    } catch (error) {
+      console.error(error);
+      setError('로그인 중 오류가 발생했습니다.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
 
-                    {error && (
-                        <div className="text-red-400 text-sm text-center">
-                            {error}
-                        </div>
-                    )}
-
-                    <div>
-                        <button
-                            type="submit"
-                            disabled={isLoading}
-                            className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-purple-600 hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-purple-500 disabled:opacity-50 disabled:cursor-not-allowed"
-                        >
-                            {isLoading ? '로그인 중...' : '로그인'}
-                        </button>
-                    </div>
-
-                    <div className="text-center">
-                        <p className="text-sm text-gray-300">
-                            계정이 없으신가요?{' '}
-                            <Link
-                                href="/auth/signup"
-                                className="font-medium text-purple-400 hover:text-purple-300"
-                            >
-                                회원가입하기
-                            </Link>
-                        </p>
-                    </div>
-                </form>
-            </div>
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-purple-900 via-blue-900 to-indigo-900">
+      <div className="w-full max-w-md space-y-8 p-8">
+        <div className="text-center">
+          <h2 className="mt-6 text-3xl font-bold text-white">로그인</h2>
+          <p className="mt-2 text-sm text-gray-300">아티스트 펀딩 협업 플랫폼에 오신 것을 환영합니다</p>
         </div>
-    );
+
+        <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
+          <div className="space-y-4">
+            <div>
+              <label htmlFor="email" className="block text-sm font-medium text-gray-300">
+                이메일
+              </label>
+              <input
+                id="email"
+                name="email"
+                type="email"
+                required
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-white shadow-sm placeholder-gray-400 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-purple-500"
+                placeholder="이메일을 입력하세요"
+              />
+            </div>
+
+            <div>
+              <label htmlFor="password" className="block text-sm font-medium text-gray-300">
+                비밀번호
+              </label>
+              <input
+                id="password"
+                name="password"
+                type="password"
+                required
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-white shadow-sm placeholder-gray-400 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-purple-500"
+                placeholder="비밀번호를 입력하세요"
+              />
+            </div>
+
+            <div className="flex items-center justify-between">
+              <label className="flex items-center space-x-2 text-sm text-gray-300">
+                <input
+                  id="remember"
+                  type="checkbox"
+                  checked={rememberMe}
+                  onChange={(event) => setRememberMe(event.target.checked)}
+                  className="h-4 w-4 rounded border-gray-600 bg-gray-800 text-purple-500 focus:ring-purple-500"
+                />
+                <span>이 브라우저 기억하기</span>
+              </label>
+
+              <button
+                type="submit"
+                disabled={isLoading}
+                className="flex items-center justify-center rounded-md border border-transparent bg-purple-600 px-4 py-2 text-sm font-medium text-white hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {isLoading ? '로그인 중...' : '로그인'}
+              </button>
+            </div>
+          </div>
+
+          {error && <div className="text-center text-sm text-red-400">{error}</div>}
+
+          <div className="text-center text-sm text-gray-300">
+            계정이 없으신가요?{' '}
+            <Link href="/auth/signup" className="font-medium text-purple-400 hover:text-purple-300">
+              회원가입하기
+            </Link>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
 }

--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -56,7 +56,26 @@ export default function SignUpPage() {
             });
 
             if (response.ok) {
-                // 회원가입 성공 시 자동 로그인
+                const loginResponse = await fetch('/api/auth/login', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                    credentials: 'include',
+                    body: JSON.stringify({
+                        email: formData.email,
+                        password: formData.password,
+                        rememberMe: true,
+                        client: 'web',
+                    }),
+                });
+
+                if (!loginResponse.ok) {
+                    const payload = await loginResponse.json().catch(() => ({ error: '자동 로그인에 실패했습니다.' }));
+                    setError(payload.error ?? '회원가입은 완료되었지만 자동 로그인에 실패했습니다. 로그인 페이지에서 다시 시도해주세요.');
+                    return;
+                }
+
                 const result = await signIn('credentials', {
                     email: formData.email,
                     password: formData.password,

--- a/docs/auth-session-policy.md
+++ b/docs/auth-session-policy.md
@@ -1,0 +1,126 @@
+# 인증 세션·토큰 운영 정책
+
+콜라보리움의 웹/모바일 서비스 전반에서 일관된 인증 보안 수칙을 유지하기 위해 세션과 토큰 관리 정책을 정리했습니다. 앱/백오피스/SDK 구현 시 본 문서를 우선 검토하고 예외가 필요한 경우 보안 팀과 상의하세요.
+
+## 1. 용어와 구성요소
+- **Access Token (AT)**: 서버 API 호출 전용의 단기 토큰입니다. JWT 또는 불투명 토큰을 허용하되 기본은 JWT를 사용합니다.
+- **Refresh Token (RT)**: AT 재발급 전용의 장기 토큰입니다. 모든 RT는 강제 회전(매 사용 시 1회용 소모)과 난수 기반 nonce를 적용합니다.
+- **Session Record**: 서버 DB에서 사용자·디바이스·RT 상태를 추적하는 레코드로, 활성/폐기 플래그와 최근 사용 시각, IP/UA 지문을 유지합니다.
+- **Device Trust**: "이 브라우저 기억하기" 옵션을 활성화한 디바이스에 대해 슬라이딩 만료를 완화하는 플래그입니다.
+
+## 2. 기본 만료 시간
+| 시나리오 | Access Token | Refresh Token 슬라이딩 만료(비활성 기준) | Refresh Token 절대 만료 |
+| --- | --- | --- | --- |
+| 일반 웹 | 15분 | 14일 | 60일 |
+| Remember me (웹) | 15분 | 30일 | 90일 |
+| 모바일 SDK | 15분 | 30일 | 180일 |
+| 어드민(백오피스) | 10분 | 7일 | 30일 |
+
+- 슬라이딩 만료는 RT로 재발급 시 `inactivity window`(14/30일)를 갱신하지만, 절대 만료(60/90/180일)는 갱신되지 않습니다.
+- 웹 UI는 사용자 인터랙션이 12시간 동안 없으면 자동 로그아웃을 수행합니다.
+
+## 3. 저장·전송 보안
+- **웹**: AT는 메모리에만 저장합니다. RT는 `__Host-refresh_token` HttpOnly 쿠키에만 저장하며 `Secure`, `SameSite=Strict`, `Path=/auth`, Host-Only 속성을 지킵니다.
+- **모바일/데스크톱**: RT는 iOS Keychain, Android Keystore 등 보안 스토리지에 저장합니다.
+- **서버**: RT는 64바이트 이상의 난수 불투명 토큰을 생성하고 Argon2 또는 bcrypt로 해시하여 저장합니다. JWT는 AT에만 사용하며 RT는 서버 검증형 불투명 토큰으로 유지합니다.
+
+## 4. 토큰 회전 및 도난 대응
+- 모든 `/auth/refresh` 요청마다 기존 RT를 폐기하고 새 AT·RT를 발급합니다.
+- 동일 RT가 재사용되면 즉시 세션을 폐기하고 사용자 알림을 발송합니다. 필요 시 최근 1시간 내 동일 디바이스의 활성 RT도 함께 폐기합니다.
+- 동일 세션에서 /24 IP 대역이나 UA 지문이 급격히 변하면 재인증(MFA 또는 비밀번호)을 요구합니다. 어드민 세션은 항상 재인증을 요구합니다.
+
+## 5. 만료·로그아웃·폐기 규칙
+- 명시적 로그아웃은 해당 세션 RT를 폐기하고 쿠키를 제거합니다.
+- 비밀번호 변경, 이메일 변경, MFA 활성화 등 보안 이벤트가 발생하면 기본적으로 모든 세션을 강제 로그아웃합니다.
+- 계정 탈퇴나 정지 시 모든 세션과 RT를 폐기합니다.
+- RT가 절대 만료에 도달하면 재발급을 거부하고 완전 재로그인을 요구합니다.
+
+## 6. 백엔드 스키마 개요
+```sql
+sessions(
+  id, user_id, device_id, created_at, last_used_at,
+  ip_hash, ua_hash, remember, is_admin, revoked_at
+)
+refresh_tokens(
+  id, session_id, token_hash, created_at, expires_at,
+  used_at, rotated_to_id, revoked_at
+)
+token_blacklist(jti, expires_at) -- JWT AT에 jti를 사용 시 필요
+
+devices(
+  id, user_id, device_fingerprint,
+  first_seen_at, last_seen_at, label
+)
+```
+- 필수 인덱스: `refresh_tokens.session_id`, `refresh_tokens.token_hash UNIQUE`, `sessions.user_id`, `sessions.last_used_at`.
+
+## 7. API 계약 요약
+- **POST `/auth/login`**: 자격 증명 검증 → 세션 생성 → AT(15분)·RT 발급 → `__Host-refresh_token` 쿠키 세팅.
+- **POST `/auth/refresh`**: 쿠키에서 RT 추출 → 미사용·미만료·미폐기 상태 확인 → 회전 → 새 AT·RT 발급 → 이전 RT의 `used_at` 기록.
+- **POST `/auth/logout`**: 현재 세션의 RT와 세션을 폐기하고 쿠키 삭제.
+- **POST `/auth/logout-all`**: 모든 세션 폐기(보안 이벤트·분실 디바이스 대응).
+- **GET `/auth/sessions`**: 활성 디바이스/세션 목록 조회와 개별 종료 기능 제공.
+
+## 8. 쿠키·헤더·CORS 설정
+- 인증이 필요한 API 호출 시 `Authorization: Bearer <access_jwt>`를 사용합니다.
+- CSRF 방지는 `/auth/refresh`를 전용 경로로 제한하고 `SameSite=Strict` 쿠키 또는 Double Submit 전략을 적용합니다.
+- CORS는 `credentials=true`와 허용 오리진 화이트리스트를 사용합니다.
+
+## 9. UX 정책
+- 자동 로그아웃 5분 전 토스트 알림을 제공하고 사용자가 연장하면 `/auth/refresh`를 호출합니다.
+- 새 디바이스 로그인 시 이메일 또는 푸시 알림을 발송합니다.
+- 세션 관리 화면에 최근 로그인 시간, 대략적 위치, 기기 이름, 종료 버튼을 표시합니다.
+
+## 10. 감사·로깅·보관
+- 로그인 성공/실패, RT 재사용 감지, 세션 폐기, 중요 설정 변경을 로깅합니다.
+- 보안 이벤트 로그는 1년, 일반 세션 로그는 90일간 보관합니다.
+- 개인정보 최소화를 위해 IP는 해시 또는 부분 마스킹 형태로 저장합니다.
+
+## 11. 운영 한계치·레이트리밋
+- **POST `/auth/login`**: IP 기준 5회/분, 계정 기준 10회/10분.
+- **POST `/auth/refresh`**: 세션 기준 30회/시간.
+
+## 12. Next.js·NextAuth 구현 메모
+- `session.strategy = "jwt"`를 유지하되 RT 관리는 커스텀 DB 테이블을 사용합니다.
+- AT는 `exp=15m`, `jti` 포함 JWT로 발급합니다.
+- `/app/api/auth/refresh/route.ts`에서 회전 로직을 구현하고 Host 쿠키 세팅 유틸을 제공합니다.
+- 예시:
+  ```ts
+  export async function POST(req: NextRequest) {
+    const rt = req.cookies.get('__Host-refresh_token')?.value;
+    if (!rt) return NextResponse.json({ error: 'no rt' }, { status: 401 });
+  
+    const record = await findRT(rt); // token_hash 비교
+    if (!record || record.used_at || record.revoked_at || isExpired(record)) {
+      await revokeSession(record?.session_id);
+      return NextResponse.json({ error: 'invalid rt' }, { status: 401 });
+    }
+  
+    const session = await getSession(record.session_id);
+    if (!session || session.revoked_at) return unauthorized();
+  
+    const newAT = signAccessJWT({ sub: session.user_id }, { expiresIn: '15m' });
+    const newRT = await issueRotatedRT(session.id, record.id);
+  
+    return NextResponse.json({ access_token: newAT }, {
+      status: 200,
+      headers: {
+        'Set-Cookie': buildHostRefreshCookie(newRT),
+      },
+    });
+  }
+  ```
+
+## 13. 어드민(백오피스) 추가 규정
+- MFA를 필수로 요구하고 회사 네트워크 등 제한된 IP 대역에서만 접속 가능하도록 권장합니다.
+- 어드민 계정은 동시에 최대 3개의 디바이스에서만 세션을 유지할 수 있습니다.
+- 정산 승인, 권한 변경 등 민감 작업 전에는 비밀번호 또는 MFA 재인증을 요청합니다.
+
+## 14. 데이터 유출 및 의심 행위 대응
+- RT 재사용 또는 지역 급변을 감지하면 해당 세션을 폐기하고 필요 시 계정을 잠급니다.
+- 사용자가 비밀번호를 강제로 재설정하도록 안내하고 보안 대시보드에 자동 티켓을 생성합니다.
+- 사용자에게 즉시 알림을 발송하여 추가 대응을 유도합니다.
+
+---
+
+본 정책은 보안 위협 동향에 따라 주기적으로 업데이트됩니다. 변경 시 제품·인프라·CX 팀에 공지하고 릴리즈 노트를 남기세요.

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,6 +1,13 @@
 import '@testing-library/jest-dom';
 
+jest.mock('next/headers', () => ({
+  headers: jest.fn(() => ({
+    get: () => undefined
+  }))
+}));
+
 // Set test environment variables
-process.env.DATABASE_URL = 'postgresql://postgres.tsdnwdwcwnqygyepojaq:YGRA5XVPxEf95v26@aws-0-ap-northeast-2.pooler.supabase.com:6543/postgres';
+process.env.DATABASE_URL =
+  'postgresql://postgres.tsdnwdwcwnqygyepojaq:YGRA5XVPxEf95v26@aws-0-ap-northeast-2.pooler.supabase.com:6543/postgres';
 process.env.NEXTAUTH_SECRET = 'lash';
 process.env.NEXTAUTH_URL = 'http://localhost:3000';

--- a/lib/auth/access-token.ts
+++ b/lib/auth/access-token.ts
@@ -1,0 +1,101 @@
+import { randomUUID } from 'crypto';
+
+import { SignJWT, jwtVerify } from 'jose';
+
+import { prisma } from '@/lib/prisma';
+import { UserRole } from '@/types/prisma';
+
+export interface AccessTokenContext {
+  userId: string;
+  sessionId: string;
+  role: UserRole;
+  permissions: string[];
+  expiresIn: number;
+}
+
+export interface AccessTokenResult {
+  token: string;
+  jti: string;
+  expiresAt: Date;
+}
+
+export interface VerifiedAccessToken {
+  userId: string;
+  sessionId: string;
+  role: UserRole;
+  permissions: string[];
+  jti: string;
+  expiresAt: Date;
+}
+
+const ISSUER = 'collaborium.auth';
+
+const getSecret = () => {
+  const secret = process.env.AUTH_JWT_SECRET ?? process.env.NEXTAUTH_SECRET;
+
+  if (!secret) {
+    throw new Error('JWT secret is not configured');
+  }
+
+  return new TextEncoder().encode(secret);
+};
+
+export const issueAccessToken = async ({
+  userId,
+  sessionId,
+  role,
+  permissions,
+  expiresIn
+}: AccessTokenContext): Promise<AccessTokenResult> => {
+  const jti = randomUUID();
+  const expirationSeconds = Math.floor(Date.now() / 1000) + expiresIn;
+  const token = await new SignJWT({
+    sid: sessionId,
+    role,
+    permissions
+  })
+    .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
+    .setIssuer(ISSUER)
+    .setSubject(userId)
+    .setJti(jti)
+    .setIssuedAt()
+    .setExpirationTime(expirationSeconds)
+    .sign(getSecret());
+
+  return {
+    token,
+    jti,
+    expiresAt: new Date(expirationSeconds * 1000)
+  };
+};
+
+export const verifyAccessToken = async (token: string): Promise<VerifiedAccessToken> => {
+  const { payload } = await jwtVerify(token, getSecret(), { issuer: ISSUER });
+
+  if (!payload.sub || typeof payload.sid !== 'string' || typeof payload.jti !== 'string') {
+    throw new Error('잘못된 액세스 토큰입니다.');
+  }
+
+  const blacklisted = await prisma.tokenBlacklist.findUnique({
+    where: { jti: payload.jti }
+  });
+
+  if (blacklisted) {
+    throw new Error('만료되거나 폐기된 토큰입니다.');
+  }
+
+  const permissions = Array.isArray(payload.permissions)
+    ? (payload.permissions as string[])
+    : [];
+
+  const expirationSeconds = typeof payload.exp === 'number' ? payload.exp : undefined;
+
+  return {
+    userId: payload.sub,
+    sessionId: payload.sid,
+    role: payload.role as UserRole,
+    permissions,
+    jti: payload.jti,
+    expiresAt: expirationSeconds ? new Date(expirationSeconds * 1000) : new Date()
+  };
+};

--- a/lib/auth/cookies.ts
+++ b/lib/auth/cookies.ts
@@ -1,0 +1,21 @@
+import { serialize } from 'cookie';
+
+export const REFRESH_COOKIE = '__Host-refresh_token';
+
+export const buildRefreshCookie = (token: string, maxAgeSeconds: number) =>
+  serialize(REFRESH_COOKIE, token, {
+    httpOnly: true,
+    secure: true,
+    sameSite: 'strict',
+    path: '/auth',
+    maxAge: maxAgeSeconds
+  });
+
+export const buildRefreshCookieRemoval = () =>
+  serialize(REFRESH_COOKIE, '', {
+    httpOnly: true,
+    secure: true,
+    sameSite: 'strict',
+    path: '/auth',
+    maxAge: 0
+  });

--- a/lib/auth/crypto.ts
+++ b/lib/auth/crypto.ts
@@ -1,0 +1,24 @@
+import { createHash, randomBytes } from 'crypto';
+
+import { hash as bcryptHash, compare as bcryptCompare } from 'bcryptjs';
+
+const TOKEN_BYTE_LENGTH = 64;
+
+export const createOpaqueToken = () =>
+  randomBytes(TOKEN_BYTE_LENGTH).toString('base64url');
+
+export const fingerprintToken = (token: string) =>
+  createHash('sha256').update(token).digest('hex');
+
+export const hashToken = async (token: string) => bcryptHash(token, 12);
+
+export const verifyTokenHash = async (token: string, tokenHash: string) =>
+  bcryptCompare(token, tokenHash);
+
+export const hashClientHint = (value?: string | null) => {
+  if (!value) {
+    return null;
+  }
+
+  return createHash('sha256').update(value).digest('hex');
+};

--- a/lib/auth/password.ts
+++ b/lib/auth/password.ts
@@ -1,0 +1,18 @@
+import { timingSafeEqual } from 'crypto';
+
+import { compare } from 'bcryptjs';
+
+export const verifyPassword = async (storedHash: string, password: string) => {
+  if (storedHash.startsWith('$2')) {
+    return compare(password, storedHash);
+  }
+
+  const bufferA = Buffer.from(storedHash);
+  const bufferB = Buffer.from(password);
+
+  if (bufferA.length !== bufferB.length) {
+    return false;
+  }
+
+  return timingSafeEqual(bufferA, bufferB);
+};

--- a/lib/auth/policy.ts
+++ b/lib/auth/policy.ts
@@ -1,0 +1,58 @@
+import { UserRole } from '@/types/prisma';
+
+export type ClientKind = 'web' | 'mobile';
+
+export interface SessionPolicy {
+  accessTokenTtl: number;
+  refreshSlidingTtl: number;
+  refreshAbsoluteTtl: number;
+}
+
+const MINUTE = 60;
+const DAY = 60 * 60 * 24;
+
+const WEB_POLICY: SessionPolicy = {
+  accessTokenTtl: 15 * MINUTE,
+  refreshSlidingTtl: 14 * DAY,
+  refreshAbsoluteTtl: 60 * DAY
+};
+
+const WEB_REMEMBER_POLICY: SessionPolicy = {
+  accessTokenTtl: 15 * MINUTE,
+  refreshSlidingTtl: 30 * DAY,
+  refreshAbsoluteTtl: 90 * DAY
+};
+
+const MOBILE_POLICY: SessionPolicy = {
+  accessTokenTtl: 15 * MINUTE,
+  refreshSlidingTtl: 30 * DAY,
+  refreshAbsoluteTtl: 180 * DAY
+};
+
+const ADMIN_POLICY: SessionPolicy = {
+  accessTokenTtl: 10 * MINUTE,
+  refreshSlidingTtl: 7 * DAY,
+  refreshAbsoluteTtl: 30 * DAY
+};
+
+export interface ResolvePolicyParams {
+  role: UserRole;
+  remember: boolean;
+  client: ClientKind;
+}
+
+export const resolveSessionPolicy = ({
+  role,
+  remember,
+  client
+}: ResolvePolicyParams): SessionPolicy => {
+  if (role === UserRole.ADMIN) {
+    return ADMIN_POLICY;
+  }
+
+  if (client === 'mobile') {
+    return MOBILE_POLICY;
+  }
+
+  return remember ? WEB_REMEMBER_POLICY : WEB_POLICY;
+};

--- a/lib/auth/session-store.ts
+++ b/lib/auth/session-store.ts
@@ -1,0 +1,365 @@
+import type { AuthSession, RefreshToken } from '@prisma/client';
+
+import { prisma } from '@/lib/prisma';
+import { UserRole } from '@/types/prisma';
+
+import { issueAccessToken } from './access-token';
+import type { ClientKind } from './policy';
+import { resolveSessionPolicy } from './policy';
+import { createOpaqueToken, fingerprintToken, hashClientHint, hashToken, verifyTokenHash } from './crypto';
+import { deriveEffectivePermissions } from './permissions';
+import { fetchUserWithPermissions } from './user';
+
+interface IssueSessionInput {
+  userId: string;
+  role: UserRole;
+  remember: boolean;
+  client: ClientKind;
+  ipAddress?: string | null;
+  userAgent?: string | null;
+  deviceFingerprint?: string | null;
+  deviceLabel?: string | null;
+}
+
+export interface IssuedSession {
+  accessToken: string;
+  accessTokenExpiresAt: Date;
+  refreshToken: string;
+  refreshRecord: RefreshToken;
+  session: AuthSession;
+  permissions: string[];
+}
+
+interface RefreshResult {
+  accessToken: string;
+  accessTokenExpiresAt: Date;
+  refreshToken: string;
+  refreshRecord: RefreshToken;
+  session: AuthSession;
+  permissions: string[];
+}
+
+const now = () => new Date();
+
+const loadUserPermissions = async (userId: string, fallbackRole: UserRole) => {
+  const user = await fetchUserWithPermissions(userId);
+
+  if (!user) {
+    return { role: fallbackRole, permissions: [] };
+  }
+
+  const explicitPermissions = user.permissions.map((entry) => entry.permission.key);
+
+  return {
+    role: user.role as UserRole,
+    permissions: deriveEffectivePermissions(user.role as UserRole, explicitPermissions)
+  };
+};
+
+const persistDevice = async (
+  userId: string,
+  deviceFingerprint?: string | null,
+  deviceLabel?: string | null
+) => {
+  if (!deviceFingerprint) {
+    return null;
+  }
+
+  const existing = await prisma.authDevice.upsert({
+    where: {
+      userId_deviceFingerprint: {
+        userId,
+        deviceFingerprint
+      }
+    },
+    create: {
+      userId,
+      deviceFingerprint,
+      label: deviceLabel ?? undefined
+    },
+    update: {
+      lastSeenAt: now(),
+      label: deviceLabel ?? undefined
+    }
+  });
+
+  return existing;
+};
+
+export const issueSessionWithTokens = async ({
+  userId,
+  role,
+  remember,
+  client,
+  ipAddress,
+  userAgent,
+  deviceFingerprint,
+  deviceLabel
+}: IssueSessionInput): Promise<IssuedSession> => {
+  const policy = resolveSessionPolicy({ role, remember, client });
+  const current = now();
+  const absoluteExpiresAt = new Date(current.getTime() + policy.refreshAbsoluteTtl * 1000);
+  const device = await persistDevice(userId, deviceFingerprint, deviceLabel);
+  const ipHash = hashClientHint(ipAddress ?? undefined);
+  const uaHash = hashClientHint(userAgent ?? undefined);
+
+  const session = await prisma.authSession.create({
+    data: {
+      userId,
+      deviceId: device?.id,
+      ipHash: ipHash ?? undefined,
+      uaHash: uaHash ?? undefined,
+      remember,
+      isAdmin: role === UserRole.ADMIN,
+      client,
+      absoluteExpiresAt
+    }
+  });
+
+  const refreshToken = createOpaqueToken();
+  const refreshTokenHash = await hashToken(refreshToken);
+  const refreshFingerprint = fingerprintToken(refreshToken);
+  const refreshInactivity = new Date(current.getTime() + policy.refreshSlidingTtl * 1000);
+
+  const refreshRecord = await prisma.refreshToken.create({
+    data: {
+      sessionId: session.id,
+      tokenHash: refreshTokenHash,
+      tokenFingerprint: refreshFingerprint,
+      inactivityExpiresAt: refreshInactivity,
+      absoluteExpiresAt
+    }
+  });
+
+  const { permissions, role: resolvedRole } = await loadUserPermissions(userId, role);
+  const access = await issueAccessToken({
+    userId,
+    sessionId: session.id,
+    role: resolvedRole,
+    permissions,
+    expiresIn: policy.accessTokenTtl
+  });
+
+  return {
+    accessToken: access.token,
+    accessTokenExpiresAt: access.expiresAt,
+    refreshToken,
+    refreshRecord,
+    session,
+    permissions
+  };
+};
+
+export const rotateRefreshToken = async (
+  refreshToken: string,
+  {
+    ipAddress,
+    userAgent
+  }: {
+    ipAddress?: string | null;
+    userAgent?: string | null;
+  }
+): Promise<RefreshResult> => {
+  const fingerprint = fingerprintToken(refreshToken);
+  const existing = await prisma.refreshToken.findUnique({
+    where: { tokenFingerprint: fingerprint },
+    include: {
+      session: true
+    }
+  });
+
+  if (!existing) {
+    throw new Error('유효하지 않은 리프레시 토큰입니다.');
+  }
+
+  const matches = await verifyTokenHash(refreshToken, existing.tokenHash);
+
+  if (!matches) {
+    throw new Error('리프레시 토큰 검증에 실패했습니다.');
+  }
+
+  if (existing.usedAt || existing.revokedAt) {
+    const timestamp = now();
+
+    await prisma.$transaction([
+      prisma.refreshToken.update({
+        where: { id: existing.id },
+        data: { revokedAt: timestamp }
+      }),
+      prisma.authSession.update({
+        where: { id: existing.sessionId },
+        data: { revokedAt: timestamp }
+      })
+    ]);
+
+    throw new Error('재사용이 감지된 리프레시 토큰입니다.');
+  }
+
+  const session = await prisma.authSession.findUnique({
+    where: { id: existing.sessionId },
+    include: { user: { include: { permissions: { include: { permission: true } } } } }
+  });
+
+  if (!session || session.revokedAt) {
+    throw new Error('만료된 세션입니다.');
+  }
+
+  const current = now();
+
+  if (session.absoluteExpiresAt <= current || existing.absoluteExpiresAt <= current) {
+    await prisma.$transaction([
+      prisma.refreshToken.update({
+        where: { id: existing.id },
+        data: { revokedAt: current }
+      }),
+      prisma.authSession.update({
+        where: { id: session.id },
+        data: { revokedAt: current }
+      })
+    ]);
+
+    throw new Error('세션이 만료되었습니다. 다시 로그인하세요.');
+  }
+
+  if (existing.inactivityExpiresAt <= current) {
+    await prisma.$transaction([
+      prisma.refreshToken.update({
+        where: { id: existing.id },
+        data: { revokedAt: current }
+      }),
+      prisma.authSession.update({
+        where: { id: session.id },
+        data: { revokedAt: current }
+      })
+    ]);
+
+    throw new Error('장시간 활동이 없어 세션이 만료되었습니다.');
+  }
+
+  const ipHash = hashClientHint(ipAddress ?? undefined);
+  const uaHash = hashClientHint(userAgent ?? undefined);
+  const policy = resolveSessionPolicy({
+    role: session.isAdmin ? UserRole.ADMIN : (session.user.role as UserRole),
+    remember: session.remember,
+    client: session.client === 'mobile' ? 'mobile' : 'web'
+  });
+
+  const newRefreshValue = createOpaqueToken();
+  const newRefreshHash = await hashToken(newRefreshValue);
+  const newFingerprint = fingerprintToken(newRefreshValue);
+  const newInactivityExpiresAt = new Date(current.getTime() + policy.refreshSlidingTtl * 1000);
+
+  const { updatedSession, newRefreshRecord } = await prisma.$transaction(async (tx) => {
+    const updatedSession = await tx.authSession.update({
+      where: { id: session.id },
+      data: {
+        lastUsedAt: current,
+        ipHash: ipHash ?? undefined,
+        uaHash: uaHash ?? undefined
+      }
+    });
+
+    const newRefreshRecord = await tx.refreshToken.create({
+      data: {
+        sessionId: session.id,
+        tokenHash: newRefreshHash,
+        tokenFingerprint: newFingerprint,
+        inactivityExpiresAt: newInactivityExpiresAt,
+        absoluteExpiresAt: session.absoluteExpiresAt
+      }
+    });
+
+    await tx.refreshToken.update({
+      where: { id: existing.id },
+      data: {
+        usedAt: current,
+        rotatedToId: newRefreshRecord.id
+      }
+    });
+
+    return { updatedSession, newRefreshRecord };
+  });
+
+  const explicitPermissions = session.user.permissions.map((entry) => entry.permission.key);
+  const permissions = deriveEffectivePermissions(session.user.role as UserRole, explicitPermissions);
+  const access = await issueAccessToken({
+    userId: session.userId,
+    sessionId: session.id,
+    role: session.user.role as UserRole,
+    permissions,
+    expiresIn: policy.accessTokenTtl
+  });
+
+  return {
+    accessToken: access.token,
+    accessTokenExpiresAt: access.expiresAt,
+    refreshToken: newRefreshValue,
+    refreshRecord: newRefreshRecord,
+    session: updatedSession,
+    permissions
+  };
+};
+
+export const revokeSession = (sessionId: string) =>
+  prisma.authSession.update({
+    where: { id: sessionId },
+    data: { revokedAt: now() }
+  });
+
+export const revokeAllSessionsForUser = async (userId: string) => {
+  const timestamp = now();
+
+  await prisma.$transaction([
+    prisma.refreshToken.updateMany({
+      where: { session: { userId } },
+      data: {
+        revokedAt: timestamp,
+        usedAt: timestamp
+      }
+    }),
+    prisma.authSession.updateMany({
+      where: { userId },
+      data: { revokedAt: timestamp }
+    })
+  ]);
+};
+
+export const revokeSessionByRefreshToken = async (refreshToken: string) => {
+  const fingerprint = fingerprintToken(refreshToken);
+  const record = await prisma.refreshToken.findUnique({
+    where: { tokenFingerprint: fingerprint }
+  });
+
+  if (!record) {
+    return null;
+  }
+
+  const matches = await verifyTokenHash(refreshToken, record.tokenHash);
+
+  if (!matches) {
+    return null;
+  }
+
+  const session = await prisma.authSession.findUnique({ where: { id: record.sessionId } });
+
+  if (!session) {
+    return null;
+  }
+
+  await prisma.$transaction(async (tx) => {
+    await tx.refreshToken.update({
+      where: { id: record.id },
+      data: {
+        revokedAt: now(),
+        usedAt: now()
+      }
+    });
+
+    await tx.authSession.update({
+      where: { id: record.sessionId },
+      data: { revokedAt: now() }
+    });
+  });
+
+  return session;
+};

--- a/lib/auth/token-blacklist.ts
+++ b/lib/auth/token-blacklist.ts
@@ -1,0 +1,8 @@
+import { prisma } from '@/lib/prisma';
+
+export const blacklistToken = (jti: string, expiresAt: Date) =>
+  prisma.tokenBlacklist.upsert({
+    where: { jti },
+    update: { expiresAt },
+    create: { jti, expiresAt }
+  });

--- a/lib/auth/user.ts
+++ b/lib/auth/user.ts
@@ -1,0 +1,13 @@
+import { prisma } from '@/lib/prisma';
+
+export const fetchUserWithPermissions = (userId: string) =>
+  prisma.user.findUnique({
+    where: { id: userId },
+    include: {
+      permissions: {
+        include: {
+          permission: true
+        }
+      }
+    }
+  });

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "embla-carousel-autoplay": "^8.1.6",
         "embla-carousel-react": "^8.6.0",
         "i18next": "^25.1.0",
+        "jose": "^5.9.3",
         "lucide-react": "^0.487.0",
         "next": "^14.2.13",
         "next-auth": "^4.24.7",
@@ -9391,9 +9392,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "4.15.9",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
-      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -10035,6 +10036,15 @@
         }
       }
     },
+    "node_modules/next-auth/node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/next-themes": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
@@ -10331,6 +10341,15 @@
         "object-hash": "^2.2.0",
         "oidc-token-hash": "^5.0.3"
       },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/openid-client/node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -13547,21 +13566,6 @@
         "use-sync-external-store": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.33",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.33.tgz",
-      "integrity": "sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@testing-library/dom": "^10.4.1",
     "autoprefixer": "^10.4.20",
     "axios": "^1.7.8",
+    "jose": "^5.9.3",
     "bcryptjs": "^3.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -158,6 +158,8 @@ model User {
   blockedUsers     UserBlock[]           @relation("UserBlocker")
   blockedBy        UserBlock[]           @relation("UserBlocked")
   visitLogs        VisitLog[]
+  authDevices      AuthDevice[]
+  authSessions     AuthSession[]
 }
 
 model Project {
@@ -201,6 +203,63 @@ model ProjectCollaborator {
   createdAt DateTime @default(now())
 
   @@unique([projectId, userId])
+}
+
+model AuthDevice {
+  id                String        @id @default(cuid())
+  user              User          @relation(fields: [userId], references: [id])
+  userId            String
+  deviceFingerprint String
+  firstSeenAt       DateTime      @default(now())
+  lastSeenAt        DateTime      @default(now())
+  label             String?
+  sessions          AuthSession[]
+
+  @@unique([userId, deviceFingerprint])
+}
+
+model AuthSession {
+  id                String          @id @default(cuid())
+  user              User            @relation(fields: [userId], references: [id])
+  userId            String
+  device            AuthDevice?     @relation(fields: [deviceId], references: [id])
+  deviceId          String?
+  createdAt         DateTime        @default(now())
+  lastUsedAt        DateTime        @default(now())
+  ipHash            String?
+  uaHash            String?
+  remember          Boolean         @default(false)
+  isAdmin           Boolean         @default(false)
+  client            String          @default("web")
+  absoluteExpiresAt DateTime
+  revokedAt         DateTime?
+  refreshTokens     RefreshToken[]
+
+  @@index([userId])
+  @@index([lastUsedAt])
+}
+
+model RefreshToken {
+  id                  String        @id @default(cuid())
+  session             AuthSession   @relation(fields: [sessionId], references: [id])
+  sessionId           String
+  tokenHash           String
+  tokenFingerprint    String        @unique
+  createdAt           DateTime      @default(now())
+  inactivityExpiresAt DateTime
+  absoluteExpiresAt   DateTime
+  usedAt              DateTime?
+  rotatedToId         String?       @unique
+  revokedAt           DateTime?
+  rotatedTo           RefreshToken? @relation("RefreshTokenRotation", fields: [rotatedToId], references: [id])
+  rotatedFrom         RefreshToken? @relation("RefreshTokenRotation")
+
+  @@index([sessionId])
+}
+
+model TokenBlacklist {
+  jti       String   @id
+  expiresAt DateTime
 }
 
 model Funding {


### PR DESCRIPTION
## Summary
- add Prisma models and utilities to manage auth sessions, refresh tokens, and token blacklisting
- implement dedicated auth API endpoints for login, refresh, logout, and session inspection backed by rotating refresh tokens
- update authorization helpers and UI sign-in flows to consume the new token issuance logic while keeping existing NextAuth sessions functional

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_b_68dd30def2c883269def424ba671a80a