### PR TITLE
fix: avoid static warnings and prisma init noise

### DIFF
--- a/app/api/analytics/overview/route.ts
+++ b/app/api/analytics/overview/route.ts
@@ -1,12 +1,13 @@
-﻿import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 
 import { getAnalyticsOverview } from '@/lib/server/analytics';
 import { requireApiUser } from '@/lib/auth/guards';
 import { UserRole } from '@/types/prisma';
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
-    const user = await requireApiUser({ roles: [UserRole.ADMIN] });
+    const authContext = { headers: request.headers };
+    const user = await requireApiUser({ roles: [UserRole.ADMIN] }, authContext);
 
     if (user.role !== UserRole.ADMIN) {
       return NextResponse.json({ message: 'Forbidden' }, { status: 403 });
@@ -19,4 +20,3 @@ export async function GET() {
     return NextResponse.json({ message: 'Unable to load analytics overview.' }, { status: 500 });
   }
 }
-

--- a/app/api/analytics/visit/route.ts
+++ b/app/api/analytics/visit/route.ts
@@ -14,12 +14,14 @@ export async function POST(request: NextRequest) {
     const userAgent = request.headers.get('user-agent');
     const forwardedFor = request.headers.get('x-forwarded-for');
     const ipAddress = forwardedFor?.split(',')[0]?.trim() ?? request.headers.get('x-real-ip') ?? null;
+    const authorization = request.headers.get('authorization');
 
     await recordVisit({
       sessionId: body.sessionId,
       path,
       userAgent,
-      ipAddress
+      ipAddress,
+      authorization
     });
 
     return NextResponse.json({ ok: true }, { status: 201 });

--- a/app/api/announcements/[id]/route.ts
+++ b/app/api/announcements/[id]/route.ts
@@ -29,12 +29,13 @@ export async function GET(_request: NextRequest, { params }: { params: { id: str
 
 export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
   const body = await request.json();
+  const authContext = { headers: request.headers };
 
   if (body?.markAsRead) {
     let user;
 
     try {
-      user = await requireApiUser({});
+      user = await requireApiUser({}, authContext);
     } catch (error) {
       const response = handleAuthorizationError(error);
 
@@ -57,7 +58,7 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
   }
 
   try {
-    await requireApiUser({ roles: [UserRole.ADMIN] });
+    await requireApiUser({ roles: [UserRole.ADMIN] }, authContext);
   } catch (error) {
     const response = handleAuthorizationError(error);
 
@@ -95,9 +96,10 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
   }
 }
 
-export async function DELETE(_request: NextRequest, { params }: { params: { id: string } }) {
+export async function DELETE(request: NextRequest, { params }: { params: { id: string } }) {
+  const authContext = { headers: request.headers };
   try {
-    await requireApiUser({ roles: [UserRole.ADMIN] });
+    await requireApiUser({ roles: [UserRole.ADMIN] }, authContext);
   } catch (error) {
     const response = handleAuthorizationError(error);
 

--- a/app/api/announcements/route.ts
+++ b/app/api/announcements/route.ts
@@ -42,10 +42,11 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
+  const authContext = { headers: request.headers };
   let admin;
 
   try {
-    admin = await requireApiUser({ roles: [UserRole.ADMIN] });
+    admin = await requireApiUser({ roles: [UserRole.ADMIN] }, authContext);
   } catch (error) {
     const response = handleAuthorizationError(error);
 

--- a/app/api/community/[id]/comments/route.ts
+++ b/app/api/community/[id]/comments/route.ts
@@ -43,9 +43,10 @@ export async function POST(
   { params }: { params: { id: string } }
 ) {
   let sessionUser: SessionUser;
+  const authContext = { headers: request.headers };
 
   try {
-    sessionUser = await requireApiUser({});
+    sessionUser = await requireApiUser({}, authContext);
   } catch (error) {
     const response = handleAuthorizationError(error);
     if (response) {

--- a/app/api/community/[id]/route.ts
+++ b/app/api/community/[id]/route.ts
@@ -102,14 +102,15 @@ const buildPostResponse = async (postId: string, viewerId?: string | null) => {
 };
 
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: { id: string } }
 ) {
   try {
+    const authContext = { headers: request.headers };
     // 인증 체크를 더 안전하게 처리
     let viewerId: string | null = null;
     try {
-      const { user: viewer } = await evaluateAuthorization();
+      const { user: viewer } = await evaluateAuthorization({}, authContext);
       viewerId = viewer?.id || null;
     } catch (authError) {
       console.warn('Authorization check failed:', authError);
@@ -145,11 +146,12 @@ export async function PATCH(
 ) {
   const body = await request.json();
   const action = body.action; // 'like', 'dislike', 'unlike', 'undislike'
+  const authContext = { headers: request.headers };
 
   let sessionUser: SessionUser;
 
   try {
-    sessionUser = await requireApiUser({});
+    sessionUser = await requireApiUser({}, authContext);
   } catch (error) {
     const response = handleAuthorizationError(error);
     if (response) {

--- a/app/api/funding/route.ts
+++ b/app/api/funding/route.ts
@@ -228,9 +228,10 @@ async function recordSuccessfulFunding({
 
 export async function POST(request: NextRequest) {
   let sessionUser;
+  const authContext = { headers: request.headers };
 
   try {
-    sessionUser = await requireApiUser({});
+    sessionUser = await requireApiUser({}, authContext);
   } catch (error) {
     const response = handleAuthorizationError(error);
     if (response) {

--- a/app/api/partners/[id]/route.ts
+++ b/app/api/partners/[id]/route.ts
@@ -27,9 +27,10 @@ export async function GET(_request: NextRequest, { params }: { params: { id: str
 
 export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
   let sessionUser;
+  const authContext = { headers: request.headers };
 
   try {
-    sessionUser = await requireApiUser({ roles: [UserRole.PARTNER, UserRole.ADMIN] });
+    sessionUser = await requireApiUser({ roles: [UserRole.PARTNER, UserRole.ADMIN] }, authContext);
   } catch (error) {
     const response = handleAuthorizationError(error);
     if (response) {

--- a/app/api/partners/route.ts
+++ b/app/api/partners/route.ts
@@ -71,11 +71,12 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   let sessionUser;
+  const authContext = { headers: request.headers };
 
   try {
     sessionUser = await requireApiUser({
       roles: [UserRole.PARTICIPANT, UserRole.PARTNER, UserRole.ADMIN]
-    });
+    }, authContext);
   } catch (error) {
     const response = handleAuthorizationError(error);
     if (response) {

--- a/app/api/projects/[id]/route.ts
+++ b/app/api/projects/[id]/route.ts
@@ -28,9 +28,10 @@ export async function PATCH(
   { params }: { params: { id: string } }
 ) {
   let user;
+  const authContext = { headers: request.headers };
 
   try {
-    user = await requireApiUser({ roles: [UserRole.CREATOR, UserRole.ADMIN] });
+    user = await requireApiUser({ roles: [UserRole.CREATOR, UserRole.ADMIN] }, authContext);
   } catch (error) {
     const response = handleAuthorizationError(error);
     if (response) {
@@ -71,13 +72,14 @@ export async function PATCH(
 }
 
 export async function DELETE(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: { id: string } }
 ) {
   let user;
+  const authContext = { headers: request.headers };
 
   try {
-    user = await requireApiUser({ roles: [UserRole.CREATOR, UserRole.ADMIN] });
+    user = await requireApiUser({ roles: [UserRole.CREATOR, UserRole.ADMIN] }, authContext);
   } catch (error) {
     const response = handleAuthorizationError(error);
     if (response) {

--- a/app/api/projects/[id]/updates/[updateId]/route.ts
+++ b/app/api/projects/[id]/updates/[updateId]/route.ts
@@ -22,9 +22,10 @@ export async function PATCH(
   { params }: { params: { id: string; updateId: string } }
 ) {
   let user;
+  const authContext = { headers: request.headers };
 
   try {
-    user = await requireApiUser({ roles: [UserRole.CREATOR, UserRole.ADMIN] });
+    user = await requireApiUser({ roles: [UserRole.CREATOR, UserRole.ADMIN] }, authContext);
   } catch (error) {
     const response = handleAuthorizationError(error);
     if (response) {
@@ -74,13 +75,14 @@ export async function PATCH(
 }
 
 export async function DELETE(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: { id: string; updateId: string } }
 ) {
   let user;
+  const authContext = { headers: request.headers };
 
   try {
-    user = await requireApiUser({ roles: [UserRole.CREATOR, UserRole.ADMIN] });
+    user = await requireApiUser({ roles: [UserRole.CREATOR, UserRole.ADMIN] }, authContext);
   } catch (error) {
     const response = handleAuthorizationError(error);
     if (response) {

--- a/app/api/projects/[id]/updates/route.ts
+++ b/app/api/projects/[id]/updates/route.ts
@@ -82,11 +82,12 @@ const createSupporterNotification = async (
 };
 
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: { id: string } }
 ) {
   try {
-    const { user } = await evaluateAuthorization();
+    const authContext = { headers: request.headers };
+    const { user } = await evaluateAuthorization({}, authContext);
     const updates = await listProjectUpdates(params.id, user ?? undefined);
     return NextResponse.json(updates.map(serializeUpdate));
   } catch (error) {
@@ -104,9 +105,10 @@ export async function POST(
   { params }: { params: { id: string } }
 ) {
   let user;
+  const authContext = { headers: request.headers };
 
   try {
-    user = await requireApiUser({ roles: [UserRole.CREATOR, UserRole.ADMIN] });
+    user = await requireApiUser({ roles: [UserRole.CREATOR, UserRole.ADMIN] }, authContext);
   } catch (error) {
     const response = handleAuthorizationError(error);
     if (response) {

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -25,9 +25,10 @@ export async function GET() {
 
 export async function POST(request: NextRequest) {
   let user;
+  const authContext = { headers: request.headers };
 
   try {
-    user = await requireApiUser({ roles: [UserRole.CREATOR, UserRole.ADMIN] });
+    user = await requireApiUser({ roles: [UserRole.CREATOR, UserRole.ADMIN] }, authContext);
   } catch (error) {
     const response = handleAuthorizationError(error);
     if (response) {

--- a/app/api/settlement/route.ts
+++ b/app/api/settlement/route.ts
@@ -28,8 +28,9 @@ function buildError(message: string, status = 400) {
 }
 
 export async function GET(request: NextRequest) {
+  const authContext = { headers: request.headers };
   try {
-    await requireApiUser({ roles: [UserRole.CREATOR, UserRole.ADMIN, UserRole.PARTNER] });
+    await requireApiUser({ roles: [UserRole.CREATOR, UserRole.ADMIN, UserRole.PARTNER] }, authContext);
   } catch (error) {
     const response = handleAuthorizationError(error);
     if (response) {
@@ -56,8 +57,9 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
+  const authContext = { headers: request.headers };
   try {
-    await requireApiUser({ roles: [UserRole.ADMIN], permissions: ['settlement:manage'] });
+    await requireApiUser({ roles: [UserRole.ADMIN], permissions: ['settlement:manage'] }, authContext);
   } catch (error) {
     const response = handleAuthorizationError(error);
     if (response) {

--- a/lib/auth/guards.ts
+++ b/lib/auth/guards.ts
@@ -4,6 +4,7 @@ import { NextResponse } from 'next/server';
 import {
   AuthorizationStatus,
   FORBIDDEN_ROUTE,
+  type AuthorizationContext,
   type GuardRequirement,
   type SessionUser,
   evaluateAuthorization
@@ -24,9 +25,10 @@ interface RequireUserOptions extends GuardRequirement {
 }
 
 export const requireUser = async (
-  options: RequireUserOptions
+  options: RequireUserOptions,
+  context?: AuthorizationContext
 ): Promise<{ user: SessionUser }> => {
-  const { status, user } = await evaluateAuthorization(options);
+  const { status, user } = await evaluateAuthorization(options, context);
 
   if (status === AuthorizationStatus.AUTHORIZED && user) {
     return { user };
@@ -42,9 +44,10 @@ export const requireUser = async (
 };
 
 export const requireApiUser = async (
-  options: GuardRequirement
+  options: GuardRequirement,
+  context?: AuthorizationContext
 ): Promise<SessionUser> => {
-  const { status, user } = await evaluateAuthorization(options);
+  const { status, user } = await evaluateAuthorization(options, context);
 
   if (status === AuthorizationStatus.AUTHORIZED && user) {
     return user;

--- a/lib/server/analytics.ts
+++ b/lib/server/analytics.ts
@@ -12,6 +12,7 @@ interface VisitRecordInput {
   path?: string | null;
   userAgent?: string | null;
   ipAddress?: string | null;
+  authorization?: string | null;
 }
 
 export interface AnalyticsOverview {
@@ -47,7 +48,13 @@ const hashIp = (ip: string | null | undefined) => {
   }
 };
 
-export const recordVisit = async ({ sessionId, path, userAgent, ipAddress }: VisitRecordInput) => {
+export const recordVisit = async ({
+  sessionId,
+  path,
+  userAgent,
+  ipAddress,
+  authorization
+}: VisitRecordInput) => {
   const normalizedSessionId = sessionId.trim();
 
   if (!normalizedSessionId) {
@@ -55,7 +62,10 @@ export const recordVisit = async ({ sessionId, path, userAgent, ipAddress }: Vis
   }
 
   try {
-    const { user } = await evaluateAuthorization();
+    const { user } = await evaluateAuthorization(
+      {},
+      authorization ? { authorization } : undefined
+    );
 
     await prisma.visitLog.create({
       data: {


### PR DESCRIPTION
## Summary
- thread request headers through authorization helpers so API routes no longer rely on `next/headers`
- add a guarded Prisma client fallback that logs a clear warning when `DATABASE_URL` is missing instead of throwing during build

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68ddf184fea083268e5c95c0f18b042c