### PR TITLE
fix: correct moderation enum typings in admin section

### DIFF
--- a/app/admin/_components/moderation-report-section.tsx
+++ b/app/admin/_components/moderation-report-section.tsx
@@ -1,15 +1,18 @@
-﻿import { ModerationStatus, ModerationTargetType } from '@/types/prisma';
-
+import { ModerationStatus, ModerationTargetType } from '@/types/prisma';
 import { getHandledModerationReportsByPost, getOpenModerationReports } from '@/lib/server/moderation';
 
-const statusLabels: Record<ModerationStatus, string> = {
+type ModerationStatusValue = (typeof ModerationStatus)[keyof typeof ModerationStatus];
+type ModerationTargetTypeValue =
+  (typeof ModerationTargetType)[keyof typeof ModerationTargetType];
+
+const statusLabels: Record<ModerationStatusValue, string> = {
   [ModerationStatus.PENDING]: 'Pending',
   [ModerationStatus.REVIEWING]: 'Reviewing',
   [ModerationStatus.ACTION_TAKEN]: 'Action Taken',
   [ModerationStatus.DISMISSED]: 'Dismissed'
 };
 
-const targetLabels: Record<ModerationTargetType, string> = {
+const targetLabels: Record<ModerationTargetTypeValue, string> = {
   [ModerationTargetType.POST]: 'Post',
   [ModerationTargetType.COMMENT]: 'Comment'
 };


### PR DESCRIPTION
## Summary
- derive moderation status and target enum value unions from the exported Prisma enums
- use the derived unions for the moderation labels to satisfy TypeScript

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68ddf7a67a208326af982f04b8e6c805