### PR TITLE
fix: align prisma enum typing across admin reports

### DIFF
--- a/app/admin/_components/moderation-report-section.tsx
+++ b/app/admin/_components/moderation-report-section.tsx
@@ -1,9 +1,10 @@
-import { ModerationStatus, ModerationTargetType } from '@/types/prisma';
+import {
+  ModerationStatus,
+  ModerationTargetType,
+  type ModerationStatusValue,
+  type ModerationTargetTypeValue
+} from '@/types/prisma';
 import { getHandledModerationReportsByPost, getOpenModerationReports } from '@/lib/server/moderation';
-
-type ModerationStatusValue = (typeof ModerationStatus)[keyof typeof ModerationStatus];
-type ModerationTargetTypeValue =
-  (typeof ModerationTargetType)[keyof typeof ModerationTargetType];
 
 const statusLabels: Record<ModerationStatusValue, string> = {
   [ModerationStatus.PENDING]: 'Pending',
@@ -12,10 +13,12 @@ const statusLabels: Record<ModerationStatusValue, string> = {
   [ModerationStatus.DISMISSED]: 'Dismissed'
 };
 
-const targetLabels: Record<ModerationTargetTypeValue, string> = {
+const targetLabels = {
   [ModerationTargetType.POST]: 'Post',
   [ModerationTargetType.COMMENT]: 'Comment'
-};
+} as const satisfies Record<ModerationTargetTypeValue, string>;
+
+const getTargetLabel = (type: ModerationTargetTypeValue) => targetLabels[type];
 
 const dateFormatter = new Intl.DateTimeFormat('ko-KR', {
   dateStyle: 'medium',
@@ -51,7 +54,7 @@ export async function ModerationReportSection() {
               >
                 <div className="pr-4">
                   <p className="text-sm font-medium text-white">
-                    {targetLabels[report.targetType]} #{report.targetId}
+                    {getTargetLabel(report.targetType)} #{report.targetId}
                   </p>
                   <p className="mt-1 text-xs text-white/60">
                     Submitted {dateFormatter.format(report.createdAt)}

--- a/app/admin/_components/partner-approval-section.tsx
+++ b/app/admin/_components/partner-approval-section.tsx
@@ -1,8 +1,8 @@
-﻿import { PartnerType } from '@/types/prisma';
+import { PartnerType, type PartnerTypeValue } from '@/types/prisma';
 
 import { getPartnersAwaitingApproval } from '@/lib/server/partners';
 
-const partnerTypeLabels: Record<PartnerType, string> = {
+const partnerTypeLabels: Record<PartnerTypeValue, string> = {
   [PartnerType.STUDIO]: 'Studio',
   [PartnerType.VENUE]: 'Venue',
   [PartnerType.PRODUCTION]: 'Production',

--- a/app/admin/_components/settlement-queue-section.tsx
+++ b/app/admin/_components/settlement-queue-section.tsx
@@ -1,8 +1,11 @@
-﻿import { SettlementPayoutStatus } from '@/types/prisma';
+import {
+  SettlementPayoutStatus,
+  type SettlementPayoutStatusValue
+} from '@/types/prisma';
 
 import { getSettlementsPendingPayout } from '@/lib/server/settlement-queries';
 
-const statusLabels: Record<SettlementPayoutStatus, string> = {
+const statusLabels: Record<SettlementPayoutStatusValue, string> = {
   [SettlementPayoutStatus.PENDING]: 'Pending',
   [SettlementPayoutStatus.IN_PROGRESS]: 'In Progress',
   [SettlementPayoutStatus.PAID]: 'Paid'

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -81,7 +81,7 @@ export async function POST(req: NextRequest) {
   try {
     const issued = await issueSessionWithTokens({
       userId: user.id,
-      role: user.role as UserRole,
+      role: user.role,
       remember,
       client,
       ipAddress,

--- a/app/api/funding/route.ts
+++ b/app/api/funding/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
+import type { Prisma } from '@prisma/client';
+
 import {
   FundingStatus,
   PaymentProvider,
   ProjectStatus,
-  type Prisma,
   type Funding
 } from '@/types/prisma';
 import Stripe from 'stripe';

--- a/app/api/partners/route.ts
+++ b/app/api/partners/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { PartnerType, UserRole } from '@/types/prisma';
+import { UserRole, type PartnerTypeValue } from '@/types/prisma';
 
 import { handleAuthorizationError, requireApiUser } from '@/lib/auth/guards';
 import {
@@ -29,13 +29,13 @@ const parseBoolean = (value: string | null): boolean | undefined => {
   return undefined;
 };
 
-const parsePartnerType = (value: string | null): PartnerType | undefined => {
+const parsePartnerType = (value: string | null): PartnerTypeValue | undefined => {
   if (!value) {
     return undefined;
   }
 
-  if (PARTNER_TYPE_SET.has(value as PartnerType)) {
-    return value as PartnerType;
+  if (PARTNER_TYPE_SET.has(value as PartnerTypeValue)) {
+    return value as PartnerTypeValue;
   }
 
   return undefined;

--- a/app/api/settlement/route.ts
+++ b/app/api/settlement/route.ts
@@ -1,12 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
+import type { Prisma } from '@prisma/client';
+
 import {
   FundingStatus,
   PartnerMatchStatus,
   ProjectStatus,
   SettlementPayoutStatus,
   SettlementStakeholderType,
-  UserRole,
-  Prisma
+  UserRole
 } from '@/types/prisma';
 import { z } from 'zod';
 

--- a/components/ui/forms/partner-form.tsx
+++ b/components/ui/forms/partner-form.tsx
@@ -6,12 +6,12 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { PartnerType } from '@/types/prisma';
+import { PartnerType, type PartnerTypeValue } from '@/types/prisma';
 
 export type PartnerFormData = {
   name: string;
   description: string;
-  type: PartnerType;
+  type: PartnerTypeValue;
   contactInfo: string;
   location: string;
   portfolioUrl: string;
@@ -105,7 +105,7 @@ export function PartnerForm({ onSubmit, initialData, onSuccess }: PartnerFormPro
 
       <div className="space-y-2">
         <Label htmlFor="type">파트너 유형 *</Label>
-        <Select value={formData.type} onValueChange={(value) => handleChange('type', value as PartnerType)}>
+        <Select value={formData.type} onValueChange={(value) => handleChange('type', value as PartnerTypeValue)}>
           <SelectTrigger>
             <SelectValue placeholder="파트너 유형을 선택하세요" />
           </SelectTrigger>

--- a/lib/auth/access-token.ts
+++ b/lib/auth/access-token.ts
@@ -3,12 +3,12 @@ import { randomUUID } from 'crypto';
 import { SignJWT, jwtVerify } from 'jose';
 
 import { prisma } from '@/lib/prisma';
-import { UserRole } from '@/types/prisma';
+import { type UserRoleValue } from '@/types/prisma';
 
 export interface AccessTokenContext {
   userId: string;
   sessionId: string;
-  role: UserRole;
+  role: UserRoleValue;
   permissions: string[];
   expiresIn: number;
 }
@@ -22,7 +22,7 @@ export interface AccessTokenResult {
 export interface VerifiedAccessToken {
   userId: string;
   sessionId: string;
-  role: UserRole;
+  role: UserRoleValue;
   permissions: string[];
   jti: string;
   expiresAt: Date;
@@ -93,7 +93,7 @@ export const verifyAccessToken = async (token: string): Promise<VerifiedAccessTo
   return {
     userId: payload.sub,
     sessionId: payload.sid,
-    role: payload.role as UserRole,
+    role: payload.role as UserRoleValue,
     permissions,
     jti: payload.jti,
     expiresAt: expirationSeconds ? new Date(expirationSeconds * 1000) : new Date()

--- a/lib/auth/permissions.ts
+++ b/lib/auth/permissions.ts
@@ -1,8 +1,8 @@
-import { UserRole, USER_ROLE_VALUES, USER_ROLE_LABELS } from '@/types/prisma';
+import { UserRole, USER_ROLE_VALUES, USER_ROLE_LABELS, type UserRoleValue } from '@/types/prisma';
 
 export { UserRole, USER_ROLE_VALUES, USER_ROLE_LABELS };
 
-export type AppUserRole = UserRole;
+export type AppUserRole = UserRoleValue;
 
 const DEFAULT_SESSION_PERMISSION = 'session:read';
 
@@ -31,8 +31,8 @@ export function normalizeRole(value: string | null | undefined): AppUserRole {
     : UserRole.PARTICIPANT;
 }
 
-export function toPrismaRole(value: string | null | undefined): UserRole {
-  return normalizeRole(value) as UserRole;
+export function toPrismaRole(value: string | null | undefined): UserRoleValue {
+  return normalizeRole(value) as UserRoleValue;
 }
 
 export function deriveEffectivePermissions(

--- a/lib/auth/policy.ts
+++ b/lib/auth/policy.ts
@@ -1,4 +1,4 @@
-import { UserRole } from '@/types/prisma';
+import { UserRole, type UserRoleValue } from '@/types/prisma';
 
 export type ClientKind = 'web' | 'mobile';
 
@@ -36,7 +36,7 @@ const ADMIN_POLICY: SessionPolicy = {
 };
 
 export interface ResolvePolicyParams {
-  role: UserRole;
+  role: UserRoleValue;
   remember: boolean;
   client: ClientKind;
 }

--- a/lib/auth/role-guards.ts
+++ b/lib/auth/role-guards.ts
@@ -1,11 +1,11 @@
-import { UserRole } from '@/types/prisma';
+import { UserRole, type UserRoleValue } from '@/types/prisma';
 
 import { hasAllPermissions, normalizeRole } from './permissions';
 
 export interface RoleGuard {
   matcher: string;
   pattern: RegExp;
-  roles?: UserRole[];
+  roles?: UserRoleValue[];
   permissions?: string[];
 }
 

--- a/lib/auth/session-store.ts
+++ b/lib/auth/session-store.ts
@@ -1,7 +1,7 @@
 import type { AuthSession, RefreshToken } from '@prisma/client';
 
 import { prisma } from '@/lib/prisma';
-import { UserRole } from '@/types/prisma';
+import { UserRole, type UserRoleValue } from '@/types/prisma';
 
 import { issueAccessToken } from './access-token';
 import type { ClientKind } from './policy';
@@ -12,7 +12,7 @@ import { fetchUserWithPermissions } from './user';
 
 interface IssueSessionInput {
   userId: string;
-  role: UserRole;
+  role: UserRoleValue;
   remember: boolean;
   client: ClientKind;
   ipAddress?: string | null;
@@ -41,7 +41,7 @@ interface RefreshResult {
 
 const now = () => new Date();
 
-const loadUserPermissions = async (userId: string, fallbackRole: UserRole) => {
+const loadUserPermissions = async (userId: string, fallbackRole: UserRoleValue) => {
   const user = await fetchUserWithPermissions(userId);
 
   if (!user) {
@@ -51,8 +51,8 @@ const loadUserPermissions = async (userId: string, fallbackRole: UserRole) => {
   const explicitPermissions = user.permissions.map((entry) => entry.permission.key);
 
   return {
-    role: user.role as UserRole,
-    permissions: deriveEffectivePermissions(user.role as UserRole, explicitPermissions)
+    role: user.role as UserRoleValue,
+    permissions: deriveEffectivePermissions(user.role as UserRoleValue, explicitPermissions)
   };
 };
 
@@ -239,7 +239,7 @@ export const rotateRefreshToken = async (
   const ipHash = hashClientHint(ipAddress ?? undefined);
   const uaHash = hashClientHint(userAgent ?? undefined);
   const policy = resolveSessionPolicy({
-    role: session.isAdmin ? UserRole.ADMIN : (session.user.role as UserRole),
+    role: session.isAdmin ? UserRole.ADMIN : (session.user.role as UserRoleValue),
     remember: session.remember,
     client: session.client === 'mobile' ? 'mobile' : 'web'
   });
@@ -281,11 +281,14 @@ export const rotateRefreshToken = async (
   });
 
   const explicitPermissions = session.user.permissions.map((entry) => entry.permission.key);
-  const permissions = deriveEffectivePermissions(session.user.role as UserRole, explicitPermissions);
+  const permissions = deriveEffectivePermissions(
+    session.user.role as UserRoleValue,
+    explicitPermissions
+  );
   const access = await issueAccessToken({
     userId: session.userId,
     sessionId: session.id,
-    role: session.user.role as UserRole,
+    role: session.user.role as UserRoleValue,
     permissions,
     expiresIn: policy.accessTokenTtl
   });

--- a/lib/auth/session.ts
+++ b/lib/auth/session.ts
@@ -1,7 +1,7 @@
 import { getServerSession } from 'next-auth';
 import type { Session } from 'next-auth';
 import { prisma } from '@/lib/prisma';
-import { UserRole } from '@/types/prisma';
+import { type UserRoleValue } from '@/types/prisma';
 
 import { verifyAccessToken } from './access-token';
 import { authOptions } from './options';
@@ -11,12 +11,12 @@ export interface SessionUser {
   id: string;
   name?: string | null;
   email?: string | null;
-  role: UserRole;
+  role: UserRoleValue;
   permissions: string[];
 }
 
 export type GuardRequirement = {
-  roles?: UserRole[];
+  roles?: UserRoleValue[];
   permissions?: string[];
 };
 
@@ -115,7 +115,7 @@ const evaluateBearerToken = async (
     const explicitPermissions = session.user.permissions.map(
       (entry) => entry.permission.key
     );
-    const role = session.user.role as UserRole;
+    const role = session.user.role as UserRoleValue;
     const permissions = deriveEffectivePermissions(role, explicitPermissions);
 
     if (requirements.roles && !requirements.roles.includes(role)) {
@@ -175,7 +175,7 @@ export const evaluateAuthorization = async (
     };
   }
 
-  const role = normalizeRole(session.user.role) as UserRole;
+  const role = normalizeRole(session.user.role) as UserRoleValue;
   const permissions = Array.isArray(session.user.permissions)
     ? session.user.permissions
     : [];

--- a/lib/server/artists.ts
+++ b/lib/server/artists.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from 'crypto';
 import { cache } from 'react';
-import { Prisma, PostType, UserRole } from '@/types/prisma';
+import type { Prisma } from '@prisma/client';
+
+import { PostType, UserRole } from '@/types/prisma';
 
 import type { SessionUser } from '@/lib/auth/session';
 import { prisma } from '@/lib/prisma';

--- a/lib/server/moderation.ts
+++ b/lib/server/moderation.ts
@@ -1,16 +1,18 @@
 import {
   ModerationStatus,
   ModerationTargetType,
-  type ModerationReport
+  type ModerationReport,
+  type ModerationStatusValue,
+  type ModerationTargetTypeValue
 } from '@/types/prisma';
 
 import { prisma } from '@/lib/prisma';
 
 export interface ModerationReportSummary {
   id: string;
-  targetType: ModerationTargetType;
+  targetType: ModerationTargetTypeValue;
   targetId: string;
-  status: ModerationStatus;
+  status: ModerationStatusValue;
   reason: string | null;
   createdAt: Date;
   reporter: {
@@ -30,10 +32,10 @@ export interface ModerationHandledPostSummary {
     | null;
   totalReports: number;
   lastResolvedAt: Date | null;
-  latestStatus: ModerationStatus;
+  latestStatus: ModerationStatusValue;
 }
 
-const ACTIVE_REVIEW_STATUSES: ModerationStatus[] = [
+const ACTIVE_REVIEW_STATUSES: ModerationStatusValue[] = [
   ModerationStatus.PENDING,
   ModerationStatus.REVIEWING
 ];

--- a/lib/server/project-updates.ts
+++ b/lib/server/project-updates.ts
@@ -1,10 +1,5 @@
-import {
-  FundingStatus,
-  MilestoneStatus,
-  PostType,
-  Prisma,
-  UserRole
-} from '@prisma/client';
+import type { Prisma } from '@prisma/client';
+import { FundingStatus, MilestoneStatus, PostType, UserRole } from '@prisma/client';
 
 import { PostVisibility } from '@/types/prisma';
 

--- a/lib/server/projects.ts
+++ b/lib/server/projects.ts
@@ -1,5 +1,7 @@
+import type { Prisma as PrismaClientNamespace } from '@prisma/client';
+
 import { revalidatePath } from 'next/cache';
-import { Prisma, ProjectStatus, UserRole, ProjectSummary } from '@/types/prisma';
+import { Prisma, ProjectStatus, UserRole, ProjectSummary, type ProjectStatusValue } from '@/types/prisma';
 import { ZodError } from 'zod';
 
 import type { SessionUser } from '@/lib/auth/session';
@@ -37,12 +39,12 @@ export class ProjectAccessDeniedError extends Error {
 
 export type ProjectSummaryOptions = {
   ownerId?: string;
-  statuses?: ProjectStatus[];
+  statuses?: ProjectStatusValue[];
   take?: number;
 };
 
 const fetchProjectsFromDb = async (options?: ProjectSummaryOptions) => {
-  const where: Prisma.ProjectWhereInput = {};
+  const where: PrismaClientNamespace.ProjectWhereInput = {};
 
   if (options?.ownerId) {
     where.ownerId = options.ownerId;
@@ -91,7 +93,7 @@ const toProjectSummary = (project: ProjectWithCounts): ProjectSummary => {
     remainingDays,
     targetAmount: project.targetAmount,
     currentAmount: project.currentAmount,
-    status: project.status as ProjectStatus,
+    status: project.status as ProjectStatusValue,
     createdAt: project.createdAt,
     updatedAt: project.updatedAt,
     owner: {
@@ -146,18 +148,18 @@ export const getProjectSummaryById = async (id: string) => {
 
 const toJsonInput = (
   value: unknown
-): Prisma.InputJsonValue | Prisma.JsonNullValueInput => {
+): PrismaClientNamespace.InputJsonValue | PrismaClientNamespace.JsonNullValueInput => {
   if (value === undefined || value === null) {
     return Prisma.JsonNull;
   }
 
-  return value as Prisma.InputJsonValue;
+  return value as PrismaClientNamespace.InputJsonValue;
 };
 
 const buildProjectCreateData = (
   input: CreateProjectInput,
   ownerId: string
-): Prisma.ProjectUncheckedCreateInput => ({
+): PrismaClientNamespace.ProjectUncheckedCreateInput => ({
   title: input.title,
   description: input.description,
   category: input.category,
@@ -175,8 +177,8 @@ const buildProjectCreateData = (
 
 const buildProjectUpdateData = (
   input: UpdateProjectInput
-): Prisma.ProjectUncheckedUpdateInput => {
-  const data: Prisma.ProjectUncheckedUpdateInput = {};
+): PrismaClientNamespace.ProjectUncheckedUpdateInput => {
+  const data: PrismaClientNamespace.ProjectUncheckedUpdateInput = {};
 
   if (input.title !== undefined) {
     data.title = input.title;
@@ -275,7 +277,7 @@ export const createProject = async (rawInput: unknown, user: SessionUser) => {
       entity: 'Project',
       entityId: project.id,
       action: 'PROJECT_CREATED',
-      data: JSON.parse(JSON.stringify(createData)) as Prisma.InputJsonValue
+      data: JSON.parse(JSON.stringify(createData)) as PrismaClientNamespace.InputJsonValue
     }
   });
 
@@ -315,7 +317,7 @@ export const updateProject = async (id: string, rawInput: unknown, user: Session
       entity: 'Project',
       entityId: id,
       action: 'PROJECT_UPDATED',
-      data: JSON.parse(JSON.stringify(data)) as Prisma.InputJsonValue
+      data: JSON.parse(JSON.stringify(data)) as PrismaClientNamespace.InputJsonValue
     }
   });
 

--- a/lib/server/settlement-queries.ts
+++ b/lib/server/settlement-queries.ts
@@ -1,4 +1,7 @@
-import { SettlementPayoutStatus } from '@/types/prisma';
+import {
+  SettlementPayoutStatus,
+  type SettlementPayoutStatusValue
+} from '@/types/prisma';
 
 import { prisma } from '@/lib/prisma';
 
@@ -8,7 +11,7 @@ export interface SettlementSummary {
   projectTitle: string;
   totalRaised: number;
   netAmount: number;
-  payoutStatus: SettlementPayoutStatus;
+  payoutStatus: SettlementPayoutStatusValue;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -18,7 +21,7 @@ const toSummary = (settlement: {
   projectId: string;
   totalRaised: number;
   netAmount: number;
-  payoutStatus: SettlementPayoutStatus;
+  payoutStatus: SettlementPayoutStatusValue;
   createdAt: Date;
   updatedAt: Date;
   project: { id: string; title: string };

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,3 +1,5 @@
+import type { Prisma } from '@prisma/client';
+
 import {
   FundingStatus,
   MilestoneStatus,
@@ -11,8 +13,7 @@ import {
   SettlementPayoutStatus,
   SettlementStakeholderType,
   UserRole,
-  PrismaClient,
-  type Prisma
+  PrismaClient
 } from '@/types/prisma';
 
 const prisma = new PrismaClient();

--- a/types/prisma.ts
+++ b/types/prisma.ts
@@ -63,6 +63,16 @@ export const ModerationTargetType = PrismaPkg.ModerationTargetType;
 export const ModerationStatus = PrismaPkg.ModerationStatus;
 export const CommunityCategory = PrismaPkg.CommunityCategory;
 
+export type UserRoleValue = (typeof UserRole)[keyof typeof UserRole];
+export type ProjectStatusValue = (typeof ProjectStatus)[keyof typeof ProjectStatus];
+export type PartnerTypeValue = (typeof PartnerType)[keyof typeof PartnerType];
+export type SettlementPayoutStatusValue =
+  (typeof SettlementPayoutStatus)[keyof typeof SettlementPayoutStatus];
+export type ModerationStatusValue =
+  (typeof ModerationStatus)[keyof typeof ModerationStatus];
+export type ModerationTargetTypeValue =
+  (typeof ModerationTargetType)[keyof typeof ModerationTargetType];
+
 export enum PostVisibility {
   PUBLIC = 'PUBLIC',
   SUPPORTERS = 'SUPPORTERS',
@@ -152,7 +162,7 @@ export const MODERATION_TARGET_TYPE_VALUES = Object.values(ModerationTargetType)
 export const MODERATION_STATUS_VALUES = Object.values(ModerationStatus);
 
 // 한국어 라벨 매핑
-export const USER_ROLE_LABELS: Record<UserRoleType, string> = {
+export const USER_ROLE_LABELS: Record<UserRoleValue, string> = {
   [UserRole.CREATOR]: '크리에이터',
   [UserRole.PARTICIPANT]: '참여자',
   [UserRole.PARTNER]: '파트너',


### PR DESCRIPTION
## Summary
- add exported enum value types in `types/prisma.ts` and refactor auth/session modules to use the safer aliases
- update the admin moderation, settlement, and partner UI to rely on the new enum label maps
- adjust server utilities and the seed script to import Prisma namespace types directly where needed

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68de0a37b8788326ae6b5bbbe3defa61