### PR TITLE
fix: define client-safe partner type constants

### DIFF
--- a/components/ui/forms/partner-form.tsx
+++ b/components/ui/forms/partner-form.tsx
@@ -6,7 +6,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { PartnerType, type PartnerTypeValue } from '@/types/prisma';
+import { PartnerType, type PartnerTypeValue } from '@/lib/constants/partner-types';
 
 export type PartnerFormData = {
   name: string;

--- a/lib/constants/partner-types.ts
+++ b/lib/constants/partner-types.ts
@@ -1,0 +1,19 @@
+export const PartnerType = {
+  STUDIO: 'STUDIO',
+  VENUE: 'VENUE',
+  PRODUCTION: 'PRODUCTION',
+  MERCHANDISE: 'MERCHANDISE',
+  OTHER: 'OTHER'
+} as const;
+
+export type PartnerTypeValue = (typeof PartnerType)[keyof typeof PartnerType];
+
+export const PARTNER_TYPE_VALUES = Object.values(PartnerType);
+
+export const PARTNER_TYPE_LABELS: Record<PartnerTypeValue, string> = {
+  [PartnerType.STUDIO]: '스튜디오',
+  [PartnerType.VENUE]: '공연장',
+  [PartnerType.PRODUCTION]: '제작 스튜디오',
+  [PartnerType.MERCHANDISE]: '머천다이즈',
+  [PartnerType.OTHER]: '기타'
+};

--- a/types/prisma.ts
+++ b/types/prisma.ts
@@ -1,3 +1,5 @@
+import 'server-only';
+
 // Shared Prisma client types and enums
 import PrismaPkg from '@prisma/client';
 import type {


### PR DESCRIPTION
## Summary
- add a client-safe partner type constants module for partner forms
- update the partner registration form to consume the new string literal types
- mark the Prisma types barrel file as server-only to prevent client imports

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68de147fac348326b4725b200ca6efd6