### PR TITLE
fix: mark analytics overview API route as dynamic

### DIFF
--- a/app/api/analytics/overview/route.ts
+++ b/app/api/analytics/overview/route.ts
@@ -1,12 +1,15 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { headers } from 'next/headers';
+import { NextResponse } from 'next/server';
 
 import { getAnalyticsOverview } from '@/lib/server/analytics';
 import { requireApiUser } from '@/lib/auth/guards';
 import { UserRole } from '@/types/prisma';
 
-export async function GET(request: NextRequest) {
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
   try {
-    const authContext = { headers: request.headers };
+    const authContext = { headers: headers() };
     const user = await requireApiUser({ roles: [UserRole.ADMIN] }, authContext);
 
     if (user.role !== UserRole.ADMIN) {

--- a/lib/auth/session.ts
+++ b/lib/auth/session.ts
@@ -20,8 +20,12 @@ export type GuardRequirement = {
   permissions?: string[];
 };
 
+type HeaderGetter = {
+  get(name: string): string | null | undefined;
+};
+
 export interface AuthorizationContext {
-  headers?: Pick<Headers, 'get'> | null;
+  headers?: HeaderGetter | null;
   authorization?: string | null;
 }
 


### PR DESCRIPTION
## Summary
- mark the analytics overview API route as force-dynamic and switch to the Next.js headers helper for auth
- relax the authorization header context type so both Next.js header stores and standard Headers objects are supported

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68de14804b248326b9bdaa2f78ee7a04