### PR TITLE
fix: decouple prisma client exports from shared types

### DIFF
--- a/__tests__/lib/server/error-handling.test.ts
+++ b/__tests__/lib/server/error-handling.test.ts
@@ -1,5 +1,5 @@
-﻿import { NextResponse } from 'next/server';
-import { Prisma } from '@/types/prisma';
+﻿import { Prisma } from '@prisma/client';
+import { NextResponse } from 'next/server';
 import {
   buildApiError,
   createTransactionWrapper,

--- a/app/api/analytics/overview/route.ts
+++ b/app/api/analytics/overview/route.ts
@@ -1,12 +1,15 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { headers } from 'next/headers';
+import { NextResponse } from 'next/server';
 
 import { getAnalyticsOverview } from '@/lib/server/analytics';
 import { requireApiUser } from '@/lib/auth/guards';
 import { UserRole } from '@/types/prisma';
 
-export async function GET(request: NextRequest) {
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
   try {
-    const authContext = { headers: request.headers };
+    const authContext = { headers: headers() };
     const user = await requireApiUser({ roles: [UserRole.ADMIN] }, authContext);
 
     if (user.role !== UserRole.ADMIN) {

--- a/app/api/artists/[id]/follow/route.ts
+++ b/app/api/artists/[id]/follow/route.ts
@@ -1,5 +1,5 @@
+import { Prisma } from '@prisma/client';
 import { NextRequest, NextResponse } from 'next/server';
-import { Prisma } from '@/types/prisma';
 
 import { getServerAuthSession } from '@/lib/auth/session';
 import { prisma } from '@/lib/prisma';

--- a/lib/auth/session.ts
+++ b/lib/auth/session.ts
@@ -20,8 +20,12 @@ export type GuardRequirement = {
   permissions?: string[];
 };
 
+type HeaderGetter = {
+  get(name: string): string | null | undefined;
+};
+
 export interface AuthorizationContext {
-  headers?: Pick<Headers, 'get'> | null;
+  headers?: HeaderGetter | null;
   authorization?: string | null;
 }
 

--- a/lib/server/error-handling.ts
+++ b/lib/server/error-handling.ts
@@ -1,5 +1,5 @@
+import { Prisma } from '@prisma/client';
 import { NextResponse } from 'next/server';
-import { Prisma } from '@/types/prisma';
 
 export interface ApiError {
     message: string;

--- a/lib/server/partners.ts
+++ b/lib/server/partners.ts
@@ -1,14 +1,9 @@
+import { Prisma } from '@prisma/client';
 import type { Prisma as PrismaClientNamespace } from '@prisma/client';
-
 import { revalidatePath } from 'next/cache';
-import {
-  Prisma,
-  UserRole,
-  PartnerSummary,
-  type PartnerTypeValue
-} from '@/types/prisma';
 import { ZodError } from 'zod';
 
+import { UserRole, PartnerSummary, type PartnerTypeValue } from '@/types/prisma';
 import type { SessionUser } from '@/lib/auth/session';
 import { prisma } from '@/lib/prisma';
 import {

--- a/lib/server/projects.ts
+++ b/lib/server/projects.ts
@@ -1,9 +1,9 @@
+import { Prisma } from '@prisma/client';
 import type { Prisma as PrismaClientNamespace } from '@prisma/client';
-
 import { revalidatePath } from 'next/cache';
-import { Prisma, ProjectStatus, UserRole, ProjectSummary, type ProjectStatusValue } from '@/types/prisma';
 import { ZodError } from 'zod';
 
+import { ProjectStatus, UserRole, ProjectSummary, type ProjectStatusValue } from '@/types/prisma';
 import type { SessionUser } from '@/lib/auth/session';
 import { prisma } from '@/lib/prisma';
 import {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,4 +1,4 @@
-import type { Prisma } from '@prisma/client';
+import { PrismaClient, type Prisma } from '@prisma/client';
 
 import {
   FundingStatus,
@@ -12,8 +12,7 @@ import {
   ProjectStatus,
   SettlementPayoutStatus,
   SettlementStakeholderType,
-  UserRole,
-  PrismaClient
+  UserRole
 } from '@/types/prisma';
 
 const prisma = new PrismaClient();

--- a/types/prisma.ts
+++ b/types/prisma.ts
@@ -1,5 +1,5 @@
-// Shared Prisma client types and enums
-import PrismaPkg from '@prisma/client';
+// Shared Prisma client types and enums that are safe to consume on both the
+// client and the server.
 import type {
   UserRole as UserRoleType,
   ProjectStatus as ProjectStatusType,
@@ -8,6 +8,24 @@ import type {
   OrderStatus as OrderStatusType,
   PostType as PostTypeType,
   NotificationType as NotificationTypeType
+} from '@prisma/client';
+import {
+  UserRole,
+  ProjectStatus,
+  FundingStatus,
+  PaymentProvider,
+  SettlementPayoutStatus,
+  SettlementStakeholderType,
+  PartnerType,
+  PartnerMatchStatus,
+  ProductType,
+  OrderStatus,
+  PostType,
+  NotificationType,
+  MilestoneStatus,
+  ModerationTargetType,
+  ModerationStatus,
+  CommunityCategory
 } from '@prisma/client';
 
 export type {
@@ -42,26 +60,24 @@ export type {
   UserBlock
 } from '@prisma/client';
 
-const { Prisma, PrismaClient } = PrismaPkg;
-
-export { Prisma, PrismaClient };
-
-export const UserRole = PrismaPkg.UserRole;
-export const ProjectStatus = PrismaPkg.ProjectStatus;
-export const FundingStatus = PrismaPkg.FundingStatus;
-export const PaymentProvider = PrismaPkg.PaymentProvider;
-export const SettlementPayoutStatus = PrismaPkg.SettlementPayoutStatus;
-export const SettlementStakeholderType = PrismaPkg.SettlementStakeholderType;
-export const PartnerType = PrismaPkg.PartnerType;
-export const PartnerMatchStatus = PrismaPkg.PartnerMatchStatus;
-export const ProductType = PrismaPkg.ProductType;
-export const OrderStatus = PrismaPkg.OrderStatus;
-export const PostType = PrismaPkg.PostType;
-export const NotificationType = PrismaPkg.NotificationType;
-export const MilestoneStatus = PrismaPkg.MilestoneStatus;
-export const ModerationTargetType = PrismaPkg.ModerationTargetType;
-export const ModerationStatus = PrismaPkg.ModerationStatus;
-export const CommunityCategory = PrismaPkg.CommunityCategory;
+export {
+  UserRole,
+  ProjectStatus,
+  FundingStatus,
+  PaymentProvider,
+  SettlementPayoutStatus,
+  SettlementStakeholderType,
+  PartnerType,
+  PartnerMatchStatus,
+  ProductType,
+  OrderStatus,
+  PostType,
+  NotificationType,
+  MilestoneStatus,
+  ModerationTargetType,
+  ModerationStatus,
+  CommunityCategory
+};
 
 export type UserRoleValue = (typeof UserRole)[keyof typeof UserRole];
 export type ProjectStatusValue = (typeof ProjectStatus)[keyof typeof ProjectStatus];


### PR DESCRIPTION
## Summary
- remove PrismaClient exports from the shared prisma type module so client-side bundles avoid server-only dependencies
- update server logic, API handlers, and the seed script to import Prisma namespaces directly from @prisma/client

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_b_68de14804b248326b9bdaa2f78ee7a04