### PR TITLE
feat: add auth session persistence migration

### DIFF
--- a/prisma/migrations/20250202000000_add_auth_session/migration.sql
+++ b/prisma/migrations/20250202000000_add_auth_session/migration.sql
@@ -1,0 +1,69 @@
+-- CreateTable
+CREATE TABLE "AuthSession" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "deviceId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastUsedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "ipHash" TEXT,
+    "uaHash" TEXT,
+    "remember" BOOLEAN NOT NULL DEFAULT false,
+    "isAdmin" BOOLEAN NOT NULL DEFAULT false,
+    "client" TEXT NOT NULL DEFAULT 'web',
+    "absoluteExpiresAt" TIMESTAMP(3) NOT NULL,
+    "revokedAt" TIMESTAMP(3),
+
+    CONSTRAINT "AuthSession_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RefreshToken" (
+    "id" TEXT NOT NULL,
+    "sessionId" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "tokenFingerprint" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "inactivityExpiresAt" TIMESTAMP(3) NOT NULL,
+    "absoluteExpiresAt" TIMESTAMP(3) NOT NULL,
+    "usedAt" TIMESTAMP(3),
+    "rotatedToId" TEXT,
+    "revokedAt" TIMESTAMP(3),
+
+    CONSTRAINT "RefreshToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TokenBlacklist" (
+    "jti" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "TokenBlacklist_pkey" PRIMARY KEY ("jti")
+);
+
+-- CreateIndex
+CREATE INDEX "AuthSession_userId_idx" ON "AuthSession"("userId");
+
+-- CreateIndex
+CREATE INDEX "AuthSession_lastUsedAt_idx" ON "AuthSession"("lastUsedAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RefreshToken_tokenFingerprint_key" ON "RefreshToken"("tokenFingerprint");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RefreshToken_rotatedToId_key" ON "RefreshToken"("rotatedToId");
+
+-- CreateIndex
+CREATE INDEX "RefreshToken_sessionId_idx" ON "RefreshToken"("sessionId");
+
+-- AddForeignKey
+ALTER TABLE "AuthSession" ADD CONSTRAINT "AuthSession_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AuthSession" ADD CONSTRAINT "AuthSession_deviceId_fkey" FOREIGN KEY ("deviceId") REFERENCES "AuthDevice"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RefreshToken" ADD CONSTRAINT "RefreshToken_sessionId_fkey" FOREIGN KEY ("sessionId") REFERENCES "AuthSession"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RefreshToken" ADD CONSTRAINT "RefreshToken_rotatedToId_fkey" FOREIGN KEY ("rotatedToId") REFERENCES "RefreshToken"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+


### PR DESCRIPTION
## Summary
- add a Prisma migration that creates the AuthSession, RefreshToken, and TokenBlacklist tables with their indexes and foreign keys

## Testing
- npx prisma db execute --schema prisma/schema.prisma --file prisma/migrations/20250202000000_add_auth_session/migration.sql

------
https://chatgpt.com/codex/tasks/task_b_68df0a19f08c832683206ccbe74382ee