### PR TITLE
fix: run prisma migrations during build

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -39,12 +39,13 @@ KAKAO_CLIENT_SECRET=your-kakao-client-secret
 ## 🗄️ 데이터베이스 설정
 
 ### 1. Supabase에서 스키마 생성
-Supabase SQL Editor에서 다음 명령어를 실행하세요:
+프로덕션 데이터베이스에 Prisma 마이그레이션을 적용하세요:
 
-```sql
--- Prisma 스키마를 Supabase에 적용
--- (prisma/schema.prisma 파일의 내용을 SQL로 변환하여 실행)
+```bash
+npx prisma migrate deploy
 ```
+
+Vercel 빌드에서도 동일한 명령이 실행되도록 `package.json`과 `vercel.json`의 빌드 커맨드에는 `prisma migrate deploy`가 포함되어 있습니다. 최초 1회는 로컬이나 CI에서 위 명령을 직접 실행해 누락된 테이블이 없는지 확인하세요.
 
 ### 2. 테스트 계정 생성
 배포 후 다음 API를 호출하여 테스트 계정을 생성하세요:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "prisma generate && next build",
+    "build": "prisma migrate deploy && prisma generate && next build",
     "start": "next start",
     "lint": "next lint",
     "test": "jest",
@@ -16,7 +16,7 @@
     "create-accounts": "ts-node scripts/create-test-accounts.ts",
     "db:push": "prisma db push",
     "db:generate": "prisma generate",
-    "vercel-build": "prisma generate && next build"
+    "vercel-build": "prisma migrate deploy && prisma generate && next build"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-  "buildCommand": "npx prisma generate && next build",
+  "buildCommand": "npx prisma migrate deploy && npx prisma generate && next build",
   "installCommand": "npm install",
   "framework": "nextjs",
   "functions": {


### PR DESCRIPTION
## Summary
- ensure Next.js build scripts run `prisma migrate deploy` before generating the client
- align Vercel build command with the new migration-first workflow
- document the requirement to run `npx prisma migrate deploy` for Supabase deployments

## Testing
- not run (docs and configuration change only)

------
https://chatgpt.com/codex/tasks/task_b_68df0e7dc04c83268e9d874abeac8add