### PR TITLE
Ensure build pipeline runs Prisma migrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "prisma generate && next build",
+    "build": "npx prisma migrate deploy && npx prisma generate && next build",
     "start": "next start",
     "lint": "next lint",
     "test": "jest",
@@ -16,7 +16,7 @@
     "create-accounts": "ts-node scripts/create-test-accounts.ts",
     "db:push": "prisma db push",
     "db:generate": "prisma generate",
-    "vercel-build": "prisma generate && next build"
+    "vercel-build": "npx prisma migrate deploy && npx prisma generate && next build"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-  "buildCommand": "npx prisma generate && next build",
+  "buildCommand": "npx prisma migrate deploy && npx prisma generate && next build",
   "installCommand": "npm install",
   "framework": "nextjs",
   "functions": {


### PR DESCRIPTION
## Summary
- ensure the Next.js build pipeline runs `prisma migrate deploy` before generating the Prisma client both locally and on Vercel

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e06d4c8f208326b8fb69586a8e9834