### PR TITLE
Skip Prisma migrations when DATABASE_URL is absent

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "npx prisma migrate deploy && npx prisma generate && next build",
+    "build": "node scripts/build-with-prisma.js",
     "start": "next start",
     "lint": "next lint",
     "test": "jest",
@@ -16,7 +16,7 @@
     "create-accounts": "ts-node scripts/create-test-accounts.ts",
     "db:push": "prisma db push",
     "db:generate": "prisma generate",
-    "vercel-build": "npx prisma migrate deploy && npx prisma generate && next build"
+    "vercel-build": "node scripts/build-with-prisma.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/scripts/build-with-prisma.js
+++ b/scripts/build-with-prisma.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+const { spawnSync } = require('node:child_process');
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, { stdio: 'inherit', ...options });
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+const hasDatabaseUrl = Boolean(process.env.DATABASE_URL);
+
+if (!hasDatabaseUrl) {
+  console.warn('[build] DATABASE_URL is not set. Skipping `prisma migrate deploy`.');
+} else {
+  run('npx', ['prisma', 'migrate', 'deploy']);
+}
+
+run('npx', ['prisma', 'generate']);
+run('next', ['build']);


### PR DESCRIPTION
## Summary
- wrap the build process in a helper script that only runs `prisma migrate deploy` when `DATABASE_URL` is defined
- ensure Prisma client generation and the Next.js build still run through the helper script for local builds

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e06f38b6b0832689eac0fbb9581066