### PR TITLE
fix: restore korean copy and outline drizzle migration

### DIFF
--- a/app/api/funding/route.ts
+++ b/app/api/funding/route.ts
@@ -246,7 +246,7 @@ export async function POST(request: NextRequest) {
   try {
     payload = await request.json();
   } catch {
-    return buildError('?붿껌 蹂몃Ц???뺤씤?????놁뒿?덈떎.');
+    return buildError('요청 본문을 확인할 수 없습니다.');
   }
 
   const {
@@ -278,23 +278,23 @@ export async function POST(request: NextRequest) {
     : baseMetadata;
 
   if (!projectId) {
-    return buildError('?꾨줈?앺듃 ?뺣낫媛 ?꾨씫?섏뿀?듬땲??');
+    return buildError('프로젝트 정보가 누락되었습니다.');
   }
 
   const project = await prisma.project.findUnique({ where: { id: projectId } });
   if (!project) {
-    return buildError('?대떦 ?꾨줈?앺듃瑜?李얠쓣 ???놁뒿?덈떎.', 404);
+    return buildError('해당 프로젝트를 찾을 수 없습니다.', 404);
   }
 
   if (![ProjectStatus.LIVE, ProjectStatus.EXECUTING].includes(project.status as any)) {
-    return buildError('?꾩옱 ?곹깭?먯꽌??寃곗젣瑜?吏꾪뻾?????놁뒿?덈떎.', 409);
+    return buildError('현재 상태에서는 결제를 진행할 수 없습니다.', 409);
   }
 
   let stripe: Stripe;
   try {
     stripe = createStripeClient();
   } catch (error) {
-    return buildError(error instanceof Error ? error.message : 'Stripe 援ъ꽦???섎せ?섏뿀?듬땲??', 500);
+    return buildError(error instanceof Error ? error.message : 'Stripe 클라이언트를 생성할 수 없습니다.', 500);
   }
 
   // Verification path
@@ -304,14 +304,14 @@ export async function POST(request: NextRequest) {
         const paymentIntent = await stripe.paymentIntents.retrieve(paymentIntentId);
 
         if (paymentIntent.status !== 'succeeded') {
-          return buildError(`寃곗젣 ?곹깭媛 ?꾨즺?섏? ?딆븯?듬땲?? (?꾩옱 ?곹깭: ${paymentIntent.status})`, 409);
+          return buildError(`결제 상태가 완료되지 않았습니다 (현재 상태: ${paymentIntent.status})`, 409);
         }
 
         const amountReceived = ensureIntegerAmount(
           paymentIntent.amount_received ?? paymentIntent.amount
         );
         if (!amountReceived) {
-          return buildError('寃곗젣 湲덉븸???뺤씤?????놁뒿?덈떎.', 422);
+          return buildError('결제 금액을 확인할 수 없습니다.', 422);
         }
 
         const funding = await recordSuccessfulFunding({
@@ -323,7 +323,7 @@ export async function POST(request: NextRequest) {
           snapshot: pickStripeIntentSnapshot(paymentIntent)
         });
 
-        // ?뺤궛 ?먮룞 ?앹꽦 ?쒕룄
+        // 정산 자동 생성 로직
         try {
           const settlement = await createSettlementIfTargetReached(projectId);
           return NextResponse.json({
@@ -332,12 +332,12 @@ export async function POST(request: NextRequest) {
             settlement: settlement ? { id: settlement.id, status: settlement.payoutStatus } : null
           });
         } catch (settlementError) {
-          console.warn('?뺤궛 ?먮룞 ?앹꽦 ?ㅽ뙣:', settlementError);
+          console.warn('정산 자동 생성 실패:', settlementError);
           return NextResponse.json({
             status: 'recorded',
             funding,
             settlement: null,
-            warning: '??⑹? ?깃났?덉?留??뺤궛 ?앹꽦???ㅽ뙣?덉뒿?덈떎.'
+            warning: '목표 달성 여부 확인 중 정산 생성에 실패했습니다.'
           });
         }
       }
@@ -348,12 +348,12 @@ export async function POST(request: NextRequest) {
         });
 
         if (session.payment_status !== 'paid') {
-          return buildError(`泥댄겕?꾩썐???꾨즺?섏? ?딆븯?듬땲?? (?꾩옱 ?곹깭: ${session.payment_status})`, 409);
+          return buildError(`체크아웃 세션이 완료되지 않았습니다 (현재 상태: ${session.payment_status})`, 409);
         }
 
         const amountPaid = ensureIntegerAmount(session.amount_total);
         if (!amountPaid) {
-          return buildError('寃곗젣 湲덉븸???뺤씤?????놁뒿?덈떎.', 422);
+          return buildError('결제 금액을 확인할 수 없습니다.', 422);
         }
 
         const paymentIntentReference =
@@ -370,7 +370,7 @@ export async function POST(request: NextRequest) {
           snapshot: pickStripeIntentSnapshot(session)
         });
 
-        // ?뺤궛 ?먮룞 ?앹꽦 ?쒕룄
+        // 정산 자동 생성 로직
         try {
           const settlement = await createSettlementIfTargetReached(projectId);
           return NextResponse.json({
@@ -379,31 +379,31 @@ export async function POST(request: NextRequest) {
             settlement: settlement ? { id: settlement.id, status: settlement.payoutStatus } : null
           });
         } catch (settlementError) {
-          console.warn('?뺤궛 ?먮룞 ?앹꽦 ?ㅽ뙣:', settlementError);
+          console.warn('정산 자동 생성 실패:', settlementError);
           return NextResponse.json({
             status: 'recorded',
             funding,
             settlement: null,
-            warning: '??⑹? ?깃났?덉?留??뺤궛 ?앹꽦???ㅽ뙣?덉뒿?덈떎.'
+            warning: '목표 달성 여부 확인 중 정산 생성에 실패했습니다.'
           });
         }
       }
     } catch (error) {
       const message =
-        error instanceof Error ? error.message : '寃곗젣 寃利?以??ㅻ쪟媛 諛쒖깮?덉뒿?덈떎.';
+        error instanceof Error ? error.message : '결제 검증 과정에서 오류가 발생했습니다.';
       return buildError(message, 500);
     }
   }
 
   const normalisedAmount = ensureIntegerAmount(amount);
   if (!normalisedAmount) {
-    return buildError('寃곗젣 湲덉븸???щ컮瑜댁? ?딆뒿?덈떎.');
+    return buildError('결제 금액이 올바르지 않습니다.');
   }
 
   try {
     if (mode === 'checkout') {
       if (!successUrl || !cancelUrl) {
-        return buildError('Checkout ?몄뀡?먮뒗 ?깃났 諛?痍⑥냼 URL???꾩슂?⑸땲??');
+        return buildError('Checkout 세션에는 성공 및 취소 URL이 필요합니다.');
       }
 
       const session = await stripe.checkout.sessions.create({
@@ -417,7 +417,7 @@ export async function POST(request: NextRequest) {
               unit_amount: normalisedAmount,
               product_data: {
                 name: project.title,
-                description: `Collab Funding ??${project.title}`
+                description: `Collab Funding – ${project.title}`
               }
             }
           }
@@ -441,7 +441,7 @@ export async function POST(request: NextRequest) {
       automatic_payment_methods: { enabled: true },
       metadata,
       receipt_email: normalisedReceiptEmail,
-      description: `Collab Funding ??${project.title}`
+      description: `Collab Funding – ${project.title}`
     });
 
     return NextResponse.json({
@@ -450,7 +450,7 @@ export async function POST(request: NextRequest) {
       clientSecret: paymentIntent.client_secret
     });
   } catch (error) {
-    const message = error instanceof Error ? error.message : '寃곗젣 ?붿껌 泥섎━???ㅽ뙣?덉뒿?덈떎.';
+    const message = error instanceof Error ? error.message : '결제 요청 처리 중 오류가 발생했습니다.';
     return buildError(message, 500);
   }
 }

--- a/docs/drizzle-migration-plan.md
+++ b/docs/drizzle-migration-plan.md
@@ -1,0 +1,69 @@
+# Drizzle Migration Plan
+
+This document captures the groundwork required to replace the existing Prisma ORM layer
+with Drizzle across the Collaborium platform. It highlights the current blockers that were
+observed while auditing the codebase, and lays out an actionable path for the migration.
+
+## Current State Overview
+
+* Prisma client is instantiated in `lib/prisma.ts` and re-exported throughout the codebase.
+* Data access relies on nested `prisma.<model>` calls in API routes, server modules, and tests.
+* Domain types and enums are re-exported from `@prisma/client` in `types/prisma.ts`.
+* Database schema is managed in `prisma/schema.prisma` with seeds and scripts depending on
+  Prisma migrations.
+
+## Key Challenges Identified
+
+1. **Surface area of Prisma usage** – nearly every API handler and server utility depends on
+   Prisma-specific query helpers (`include`, `select`, transactions, nested writes, etc.).
+2. **Shared enum/types contract** – front-end code and shared modules import enum definitions
+   straight from `@prisma/client`, so a drop-in replacement must provide equivalent exports.
+3. **Testing and scripts** – unit tests, seed scripts, and various maintenance scripts spin up
+   Prisma clients directly, so the migration must cover those entry points as well.
+4. **Complex relations** – features such as funding settlements, community posts, and partner
+   matching rely on nested relations and aggregations that will require carefully modelled
+   Drizzle schemas and relation helpers.
+
+## Proposed Migration Strategy
+
+1. **Establish Drizzle Infrastructure**
+   * Add `drizzle-orm`, a PostgreSQL driver (e.g., `postgres`), and `drizzle-kit` to the project.
+   * Create `drizzle.config.ts` pointing at the existing database connection string.
+   * Generate a Drizzle schema (`db/schema.ts`) that mirrors the Prisma models, enumerations,
+     and relations. Start by scripting a conversion from `schema.prisma` to Drizzle table
+     definitions to minimise manual mistakes.
+   * Introduce a central `lib/db/client.ts` that exports the Drizzle database instance and
+     helper methods for handling transactions.
+
+2. **Type & Enum Bridging**
+   * Replace the `@prisma/client` enum re-exports in `types/prisma.ts` with equivalents sourced
+     from the Drizzle schema (using `pgEnum` and derived TypeScript types).
+   * Ensure any public types consumed on the client are re-created (e.g., using `InferSelectModel`).
+
+3. **Incremental Query Migration**
+   * Start with core domains (projects, funding, settlements, partners) by rewriting the
+     server modules to call Drizzle query builders or custom repository functions.
+   * Replace transactional logic (`prisma.$transaction`) with Drizzle's `db.transaction` API.
+   * Gradually update API routes to consume the new repository layer, deleting Prisma imports
+     as each route is migrated.
+
+4. **Tests & Scripts**
+   * Update seed and maintenance scripts to use the new Drizzle helpers.
+   * Refactor unit/integration tests to seed data via Drizzle or dedicated repository utilities.
+   * Remove Prisma-specific test mocks once the migration is complete.
+
+5. **Clean-Up & Verification**
+   * Remove the `prisma/` directory, Prisma dependencies, and related NPM scripts once all
+     modules have been migrated.
+   * Run full regression tests (Jest, Playwright) and execute database smoke tests to ensure the
+     new Drizzle layer produces identical results.
+
+## Immediate Next Steps
+
+* Finalise the Drizzle schema definition and set up the database client factory.
+* Introduce repository utilities for projects and funding to validate the schema and connection.
+* Incrementally port the settlement and partner modules, which surfaced the encoding issues
+  corrected in this patch, to establish the migration pattern.
+
+By following these steps we can transition from Prisma to Drizzle while preserving the existing
+business logic and keeping risk contained through incremental updates.

--- a/lib/server/error-handling.ts
+++ b/lib/server/error-handling.ts
@@ -41,26 +41,26 @@ export function handleFundingSettlementError(error: unknown): NextResponse {
     if (error instanceof Prisma.PrismaClientKnownRequestError) {
         switch (error.code) {
             case 'P2002':
-                return buildApiError('?곗씠??以묐났 ?ㅻ쪟媛 諛쒖깮?덉뒿?덈떎.', 409, 'DUPLICATE_ENTRY');
+                return buildApiError('데이터 중복 오류가 발생했습니다.', 409, 'DUPLICATE_ENTRY');
             case 'P2025':
-                return buildApiError('?붿껌???곗씠?곕? 李얠쓣 ???놁뒿?덈떎.', 404, 'NOT_FOUND');
+                return buildApiError('요청한 데이터를 찾을 수 없습니다.', 404, 'NOT_FOUND');
             case 'P2003':
-                return buildApiError('李몄“ 臾닿껐???ㅻ쪟媛 諛쒖깮?덉뒿?덈떎.', 400, 'FOREIGN_KEY_CONSTRAINT');
+                return buildApiError('참조 무결성 오류가 발생했습니다.', 400, 'FOREIGN_KEY_CONSTRAINT');
             default:
-                return buildApiError('?곗씠?곕쿋?댁뒪 ?ㅻ쪟媛 諛쒖깮?덉뒿?덈떎.', 500, 'DATABASE_ERROR');
+                return buildApiError('데이터베이스 오류가 발생했습니다.', 500, 'DATABASE_ERROR');
         }
     }
 
     if (error instanceof Prisma.PrismaClientValidationError) {
-        return buildApiError('?곗씠??寃利??ㅻ쪟媛 諛쒖깮?덉뒿?덈떎.', 400, 'VALIDATION_ERROR');
+        return buildApiError('데이터 검증 오류가 발생했습니다.', 400, 'VALIDATION_ERROR');
     }
 
     if (error instanceof Error) {
         console.error('Unexpected error:', error);
-        return buildApiError('?쒕쾭 ?대? ?ㅻ쪟媛 諛쒖깮?덉뒿?덈떎.', 500, 'INTERNAL_ERROR');
+        return buildApiError('예상치 못한 오류가 발생했습니다.', 500, 'INTERNAL_ERROR');
     }
 
-    return buildApiError('?????녿뒗 ?ㅻ쪟媛 諛쒖깮?덉뒿?덈떎.', 500, 'UNKNOWN_ERROR');
+    return buildApiError('알 수 없는 오류가 발생했습니다.', 500, 'UNKNOWN_ERROR');
 }
 
 export async function withErrorHandling<T>(

--- a/lib/server/partners.ts
+++ b/lib/server/partners.ts
@@ -102,7 +102,7 @@ type PartnerWithRelations = PrismaTypes.PartnerGetPayload<{
   };
 }>;
 
-// PartnerSummary???댁젣 @/types/prisma?먯꽌 import??
+// PartnerSummary 타입은 @/types/prisma에서 import합니다
 
 const toPartnerSummary = (partner: PartnerWithRelations): PartnerSummary => {
   // const services = Array.isArray(partner.services)
@@ -167,32 +167,32 @@ export class PartnerValidationError extends Error {
   issues: string[];
 
   constructor(error: ZodError) {
-    super('?뚰듃???뺣낫媛 ?좏슚?섏? ?딆뒿?덈떎.');
+    super('파트너 정보가 유효하지 않습니다.');
     this.issues = error.issues.map((issue) => issue.message);
   }
 }
 
 export class PartnerProfileExistsError extends Error {
   constructor() {
-    super('?대? ?깅줉???뚰듃???꾨줈?꾩씠 ?덉뒿?덈떎.');
+    super('이미 등록된 파트너 프로필이 있습니다.');
   }
 }
 
 export class PartnerOwnerNotFoundError extends Error {
   constructor() {
-    super('?뚰듃???뚯쑀???뺣낫瑜?李얠쓣 ???놁뒿?덈떎.');
+    super('파트너 소유자 정보를 찾을 수 없습니다.');
   }
 }
 
 export class PartnerNotFoundError extends Error {
   constructor() {
-    super('?뚰듃???뺣낫瑜?李얠쓣 ???놁뒿?덈떎.');
+    super('파트너 정보를 찾을 수 없습니다.');
   }
 }
 
 export class PartnerAccessDeniedError extends Error {
   constructor() {
-    super('?뚰듃???뺣낫瑜??섏젙??沅뚰븳???놁뒿?덈떎.');
+    super('파트너 정보를 수정할 권한이 없습니다.');
   }
 }
 

--- a/lib/server/projects.ts
+++ b/lib/server/projects.ts
@@ -21,20 +21,20 @@ export class ProjectValidationError extends Error {
   issues: string[];
 
   constructor(error: ZodError) {
-    super('?꾨줈?앺듃 ?낅젰 媛믪씠 ?щ컮瑜댁? ?딆뒿?덈떎.');
+    super('프로젝트 입력 값이 올바르지 않습니다.');
     this.issues = error.issues.map((issue) => issue.message);
   }
 }
 
 export class ProjectNotFoundError extends Error {
   constructor() {
-    super('?꾨줈?앺듃瑜?李얠쓣 ???놁뒿?덈떎.');
+    super('프로젝트를 찾을 수 없습니다.');
   }
 }
 
 export class ProjectAccessDeniedError extends Error {
   constructor() {
-    super('?꾨줈?앺듃?????沅뚰븳???놁뒿?덈떎.');
+    super('프로젝트에 접근할 권한이 없습니다.');
   }
 }
 


### PR DESCRIPTION
## Summary
- replace mojibake in funding and settlement API responses with clear Korean copy and adjust related logging
- restore readable Korean error messaging across project and partner server utilities
- document the proposed end-to-end plan for migrating the ORM layer from Prisma to Drizzle

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e37b89e3bc8326b090e712c6680d29