### PR TITLE
refactor: migrate auth registration flow to drizzle

### DIFF
--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { hash } from 'bcryptjs';
-import { prisma } from '@/lib/prisma';
-import { UserRole } from '@/types/prisma';
+
+import { createParticipantUser, findUserByEmail } from '@/lib/auth/user';
 
 export async function POST(request: NextRequest) {
     try {
@@ -24,9 +24,7 @@ export async function POST(request: NextRequest) {
         }
 
         // 이메일 중복 확인
-        const existingUser = await prisma.user.findUnique({
-            where: { email }
-        });
+        const existingUser = await findUserByEmail(email);
 
         if (existingUser) {
             return NextResponse.json(
@@ -39,20 +37,10 @@ export async function POST(request: NextRequest) {
         const hashedPassword = await hash(password, 12);
 
         // 사용자 생성
-        const user = await prisma.user.create({
-            data: {
-                name,
-                email,
-                passwordHash: hashedPassword,
-                role: UserRole.PARTICIPANT,
-            },
-            select: {
-                id: true,
-                name: true,
-                email: true,
-                role: true,
-                createdAt: true,
-            }
+        const user = await createParticipantUser({
+            name,
+            email,
+            passwordHash: hashedPassword,
         });
 
         return NextResponse.json({

--- a/lib/auth/access-token.ts
+++ b/lib/auth/access-token.ts
@@ -2,7 +2,10 @@ import { randomUUID } from 'crypto';
 
 import { SignJWT, jwtVerify } from 'jose';
 
-import { prisma } from '@/lib/prisma';
+import { eq } from 'drizzle-orm';
+
+import { db } from '@/lib/db/client';
+import { tokenBlacklist } from '@/lib/db/schema';
 import type { UserRoleType } from '@/types/prisma';
 
 export interface AccessTokenContext {
@@ -76,8 +79,8 @@ export const verifyAccessToken = async (token: string): Promise<VerifiedAccessTo
     throw new Error('잘못된 액세스 토큰입니다.');
   }
 
-  const blacklisted = await prisma.tokenBlacklist.findUnique({
-    where: { jti: payload.jti }
+  const blacklisted = await db.query.tokenBlacklist.findFirst({
+    where: eq(tokenBlacklist.jti, payload.jti)
   });
 
   if (blacklisted) {


### PR DESCRIPTION
## Summary
- refactor the auth access token verification and session guard to query Drizzle instead of Prisma
- add user repository helpers to create and lookup accounts with Drizzle and reuse them from the registration API
- update registration API tests to mock the new helpers

## Testing
- npm test -- __tests__/api/auth/register.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68e5049e08808326a7dec6e8a9311eef