### PR TITLE
refactor: split home page into modular sections

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,35 +1,23 @@
 'use client';
 
-import { useMemo } from 'react';
-import Image from 'next/image';
-import Link from 'next/link';
 import { useQuery } from '@tanstack/react-query';
-import { Sparkles } from 'lucide-react';
-import { useTranslation } from 'react-i18next';
 
-import { CategoryFilter } from '@/components/ui/sections/category-filter';
-import { ProjectCard } from '@/components/ui/cards/project-card';
-import { SectionHeader } from '@/components/ui/headers/section-header';
-import { StoreCard } from '@/components/ui/cards/store-card';
-import type { ProjectSummary } from '@/lib/api/projects';
+import { ArtistNetworkSection } from '@/components/home/artist-network-section';
+import { CommunityPulseSection } from '@/components/home/community-pulse-section';
+import { HeroSection } from '@/components/home/hero-section';
+import { ProjectSpotlightSection } from '@/components/home/project-spotlight-section';
+import { ResourcesSection } from '@/components/home/resources-section';
+import { StoreSection } from '@/components/home/store-section';
 import { fetchProjects } from '@/lib/api/projects';
 import { fetchStoreItems } from '@/lib/api/store';
 import type { CommunityFeedResponse } from '@/lib/data/community';
+import type { HomeArtistSummary } from '@/types/home';
 
 interface ArtistListResponse {
-  artists: {
-    id: string;
-    name: string;
-    avatarUrl: string | null;
-    bio: string | null;
-    followerCount: number;
-    projectCount: number;
-  }[];
+  artists: HomeArtistSummary[];
 }
 
 export default function HomePage() {
-  const { t } = useTranslation();
-
   const { data: storeItems = [], isLoading: storeLoading } = useQuery({
     queryKey: ['store-items'],
     queryFn: fetchStoreItems,
@@ -70,305 +58,32 @@ export default function HomePage() {
   const communityPosts = communityResponse?.posts ?? [];
   const [featuredPost, ...highlightedPosts] = communityPosts;
 
-  const popularProjects = useMemo(() => {
-    return [...projects].sort((a, b) => b.participants - a.participants).slice(0, 6);
-  }, [projects]);
-
-  const ProjectSkeleton = ({ className = '' }: { className?: string }) => (
-    <div className={`flex h-full flex-col overflow-hidden rounded-3xl border border-white/10 bg-white/5 ${className}`}>
-      <div className="h-52 w-full bg-white/10" />
-      <div className="flex flex-1 flex-col justify-between gap-4 p-5">
-        <div className="space-y-2">
-          <div className="h-3 w-1/3 rounded-full bg-white/10" />
-          <div className="h-5 w-3/4 rounded-full bg-white/20" />
-          <div className="h-3 w-1/2 rounded-full bg-white/10" />
-        </div>
-        <div className="space-y-2">
-          <div className="h-2 rounded-full bg-white/10" />
-          <div className="h-3 w-2/3 rounded-full bg-white/10" />
-        </div>
-      </div>
-    </div>
-  );
-
-  const renderProjects = (items: ProjectSummary[]) => {
-    if (isLoading) {
-      return (
-        <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
-          {Array.from({ length: 6 }).map((_, index) => (
-            <ProjectSkeleton key={`skeleton-${index}`} className="animate-pulse" />
-          ))}
-        </div>
-      );
-    }
-
-    if (isError) {
-      return (
-        <div className="rounded-3xl border border-red-500/30 bg-red-500/10 p-6 text-sm text-red-100">
-          <p>{t('home.errors.projects')}</p>
-          <button
-            type="button"
-            onClick={() => refetch()}
-            className="mt-4 inline-flex items-center rounded-full border border-red-400/40 px-4 py-2 text-xs font-semibold text-red-100 transition hover:border-red-300/60 hover:text-red-50"
-          >
-            {t('actions.viewMore')}
-          </button>
-        </div>
-      );
-    }
-
-    if (items.length === 0) {
-      return (
-        <div className="rounded-3xl border border-white/10 bg-white/5 p-6 text-sm text-white/60">
-          {t('home.empty.projects')}
-        </div>
-      );
-    }
-
-    return (
-      <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
-        {items.map((project) => (
-          <ProjectCard key={project.id} project={project} />
-        ))}
-      </div>
-    );
-  };
-
   return (
     <div className="mx-auto flex max-w-7xl flex-col gap-16 px-4 pb-20">
-      <section className="pt-6">
-        <div className="grid gap-8 rounded-4xl border border-white/10 bg-gradient-to-br from-neutral-900 via-neutral-950 to-neutral-950 p-10 lg:grid-cols-[3fr_2fr] lg:items-center">
-          <div className="space-y-6">
-            <span className="inline-flex items-center gap-2 rounded-full border border-white/20 px-4 py-1 text-xs font-semibold uppercase tracking-[0.4em] text-white/60">
-              <Sparkles className="h-4 w-4" />
-              {t('home.hero.tagline')}
-            </span>
-            <h1 className="text-4xl font-semibold leading-tight text-white md:text-5xl">
-              {t('home.hero.title')}
-            </h1>
-            <p className="max-w-2xl text-base text-white/70">{t('home.hero.subtitle')}</p>
-            <div className="flex flex-wrap gap-3">
-              <Link
-                href="/artists"
-                className="inline-flex items-center gap-2 rounded-full bg-primary px-5 py-2 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90"
-              >
-                {t('home.hero.ctaArtists')}
-              </Link>
-              <Link
-                href="/community"
-                className="inline-flex items-center gap-2 rounded-full border border-white/20 px-5 py-2 text-sm font-semibold text-white transition hover:border-white/40 hover:text-white"
-              >
-                {t('home.hero.ctaCommunity')}
-              </Link>
-            </div>
-          </div>
-          <div className="grid gap-4 rounded-3xl border border-white/10 bg-white/5 p-6 text-sm text-white/70">
-            <div className="flex items-center justify-between">
-              <span>{t('home.hero.metrics.projects')}</span>
-              <span className="text-2xl font-semibold text-white">{projects.length}</span>
-            </div>
-            <div className="flex items-center justify-between">
-              <span>{t('home.hero.metrics.community')}</span>
-              <span className="text-2xl font-semibold text-white">{communityPosts.length}</span>
-            </div>
-            <div className="flex items-center justify-between">
-              <span>{t('home.hero.metrics.artists')}</span>
-              <span className="text-2xl font-semibold text-white">{artists.length}</span>
-            </div>
-          </div>
-        </div>
-      </section>
+      <HeroSection
+        projectsCount={projects.length}
+        communityCount={communityPosts.length}
+        artistsCount={artists.length}
+      />
 
-      <section className="grid gap-6 lg:grid-cols-[2fr_1fr]">
-        <div className="space-y-6">
-          <SectionHeader
-            title={t('home.sections.spotlight')}
-            href="/projects"
-            ctaLabel={t('actions.viewMore') ?? undefined}
-          />
-          {renderProjects(popularProjects)}
-        </div>
-        <div className="space-y-4 rounded-3xl border border-white/10 bg-white/5 p-6">
-          <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-white/60">
-            {t('home.liveAma.tag')}
-          </h3>
-          <p className="text-2xl font-semibold text-white">{t('home.liveAma.title')}</p>
-          <p className="text-sm text-white/60">{t('home.liveAma.description')}</p>
-          <Link
-            href="/projects/1"
-            className="inline-flex w-fit rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground"
-            aria-label={t('home.liveAma.ctaAria', { title: t('home.liveAma.title') })}
-          >
-            {t('home.liveAma.cta')}
-          </Link>
-        </div>
-      </section>
+      <ProjectSpotlightSection
+        projects={projects}
+        isLoading={isLoading}
+        isError={isError}
+        onRetry={refetch}
+      />
 
-      <section>
-        <SectionHeader
-          title={t('home.sections.artistNetwork')}
-          href="/artists"
-          ctaLabel={t('actions.viewMore') ?? undefined}
-        />
-        <div className="mt-6 grid gap-6 md:grid-cols-2 xl:grid-cols-4">
-          {artists.length === 0
-            ? Array.from({ length: 4 }).map((_, index) => (
-              <div key={index} className="h-56 animate-pulse rounded-3xl border border-white/10 bg-white/5" />
-            ))
-            : artists.map((artist) => (
-              <Link
-                key={artist.id}
-                href={`/artists/${artist.id}`}
-                className="group flex flex-col gap-3 rounded-3xl border border-white/10 bg-white/5 p-5 transition hover:border-primary/40 hover:bg-white/10"
-              >
-                <div className="flex items-center gap-3">
-                  <div className="relative h-14 w-14 overflow-hidden rounded-2xl border border-white/10 bg-neutral-900">
-                    {artist.avatarUrl ? (
-                      <Image src={artist.avatarUrl} alt={artist.name} fill className="object-cover" />
-                    ) : (
-                      <div className="flex h-full w-full items-center justify-center text-lg font-semibold text-white/70">
-                        {artist.name.slice(0, 2)}
-                      </div>
-                    )}
-                  </div>
-                  <div>
-                    <p className="text-base font-semibold text-white group-hover:text-primary">{artist.name}</p>
-                    <p className="text-xs uppercase tracking-[0.3em] text-white/50">
-                      {t('artist.directory.projectCount', { count: artist.projectCount })}
-                    </p>
-                  </div>
-                </div>
-                <p className="flex-1 text-sm text-white/70 line-clamp-3">{artist.bio ?? t('artist.profile.emptyBioDetailed')}</p>
-                <div className="flex items-center justify-between text-xs text-white/60">
-                  <span>{t('artist.directory.followerCount', { count: artist.followerCount })}</span>
-                  <span className="rounded-full border border-white/10 px-3 py-1 text-white/70">
-                    {t('artist.directory.viewProfile')}
-                  </span>
-                </div>
-              </Link>
-            ))}
-        </div>
-      </section>
+      <ArtistNetworkSection artists={artists} />
 
-      <section>
-        <SectionHeader
-          title={t('home.sections.communityPulse')}
-          href="/community"
-          ctaLabel={t('actions.viewMore') ?? undefined}
-        />
-        {communityPosts.length === 0 ? (
-          <div className="mt-6 rounded-3xl border border-dashed border-white/10 bg-white/5 p-10 text-center text-sm text-white/60">
-            {t('home.empty.community')}
-          </div>
-        ) : (
-          <div className="mt-6 grid gap-4 lg:grid-cols-[1.4fr_1fr] xl:grid-cols-[3fr_2fr]">
-            {featuredPost ? (
-              <Link
-                href={`/community/${featuredPost.id}`}
-                className="group flex h-full flex-col gap-6 rounded-3xl border border-white/10 bg-gradient-to-br from-white/10 via-white/5 to-white/[0.02] p-6 transition hover:border-primary/40 hover:from-primary/20 hover:via-primary/10 hover:to-primary/0"
-              >
-                <div className="flex flex-wrap items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.3em] text-white/60">
-                  <span className="rounded-full bg-white/10 px-3 py-1 text-white">
-                    {t(`community.filters.${featuredPost.category}`)}
-                  </span>
-                  {featuredPost.isTrending ? (
-                    <span className="rounded-full bg-primary/20 px-3 py-1 text-primary">
-                      {t('community.badges.trending')}
-                    </span>
-                  ) : null}
-                </div>
-                <div className="space-y-3">
-                  <h3 className="text-2xl font-semibold text-white group-hover:text-primary">
-                    {featuredPost.title}
-                  </h3>
-                  <p className="text-sm text-white/70 line-clamp-4">{featuredPost.content}</p>
-                </div>
-                <div className="flex flex-wrap items-center justify-between gap-3 text-xs text-white/60">
-                  <span>{featuredPost.author?.name ?? t('community.defaultGuestName')}</span>
-                  <div className="flex items-center gap-3">
-                    <span>{t('community.likesLabel_other', { count: featuredPost.likes ?? 0 })}</span>
-                    <span>{t('community.commentsLabel_other', { count: featuredPost.comments ?? 0 })}</span>
-                  </div>
-                </div>
-              </Link>
-            ) : null}
-            <div className="flex flex-col gap-3 rounded-3xl border border-white/10 bg-white/5 p-5">
-              <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-[0.3em] text-white/50">
-                <span>{t('home.sections.communityPulse')}</span>
-                <Link href="/community" className="text-white/60 transition hover:text-white">
-                  {t('actions.viewMore')}
-                </Link>
-              </div>
-              <div className="grid gap-3 sm:grid-cols-2">
-                {highlightedPosts.length === 0 ? (
-                  <div className="col-span-full rounded-2xl border border-dashed border-white/10 bg-white/5 p-6 text-center text-xs text-white/50">
-                    {t('home.empty.community')}
-                  </div>
-                ) : (
-                  highlightedPosts.map((post) => (
-                    <Link
-                      key={post.id}
-                      href={`/community/${post.id}`}
-                      className="group flex flex-col gap-2 rounded-2xl border border-white/10 bg-neutral-950/60 px-4 py-3 transition hover:border-primary/40 hover:bg-neutral-900/80"
-                    >
-                      <div className="flex items-center justify-between text-[11px] uppercase tracking-[0.3em] text-white/50">
-                        <span className="truncate text-white/70">
-                          {t(`community.filters.${post.category}`)}
-                        </span>
-                        {post.isTrending ? (
-                          <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[10px] text-primary">
-                            {t('community.badges.trending')}
-                          </span>
-                        ) : null}
-                      </div>
-                      <p className="text-sm font-semibold text-white group-hover:text-primary line-clamp-2">{post.title}</p>
-                      <p className="text-xs text-white/60 line-clamp-2">{post.content}</p>
-                      <div className="mt-auto flex items-center justify-between text-[11px] text-white/50">
-                        <span className="truncate">{post.author?.name ?? t('community.defaultGuestName')}</span>
-                        <span>{t('community.likesLabel_other', { count: post.likes ?? 0 })}</span>
-                      </div>
-                    </Link>
-                  ))
-                )}
-              </div>
-            </div>
-          </div>
-        )}
-      </section>
+      <CommunityPulseSection
+        featuredPost={featuredPost}
+        highlightedPosts={highlightedPosts}
+        hasPosts={communityPosts.length > 0}
+      />
 
-      <section>
-        <SectionHeader
-          title={t('home.sections.resources')}
-          href="/partners"
-          ctaLabel={t('actions.viewMore') ?? undefined}
-        />
-        <CategoryFilter />
-      </section>
+      <ResourcesSection />
 
-      <section>
-        <SectionHeader
-          title={t('home.store.title')}
-          href="/store"
-          ctaLabel={t('actions.viewMore') ?? undefined}
-        />
-        {storeLoading ? (
-          <div className="grid gap-6 md:grid-cols-3">
-            {Array.from({ length: 3 }).map((_, index) => (
-              <div key={index} className="h-64 animate-pulse rounded-3xl bg-white/10" />
-            ))}
-          </div>
-        ) : storeItems.length === 0 ? (
-          <div className="rounded-3xl border border-white/10 bg-white/5 p-6 text-sm text-white/60">
-            {t('home.empty.store')}
-          </div>
-        ) : (
-          <div className="grid gap-6 md:grid-cols-3">
-            {storeItems.map((item) => (
-              <StoreCard key={item.id} product={item} />
-            ))}
-          </div>
-        )}
-      </section>
+      <StoreSection items={storeItems} isLoading={storeLoading} />
     </div>
   );
 }

--- a/components/home/artist-network-section.tsx
+++ b/components/home/artist-network-section.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { useTranslation } from 'react-i18next';
+
+import { SectionHeader } from '@/components/ui/headers/section-header';
+import type { HomeArtistSummary } from '@/types/home';
+
+interface ArtistNetworkSectionProps {
+  artists: HomeArtistSummary[];
+}
+
+export function ArtistNetworkSection({ artists }: ArtistNetworkSectionProps) {
+  const { t } = useTranslation();
+  const hasArtists = artists.length > 0;
+
+  return (
+    <section>
+      <SectionHeader
+        title={t('home.sections.artistNetwork')}
+        href="/artists"
+        ctaLabel={t('actions.viewMore') ?? undefined}
+      />
+      <div className="mt-6 grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+        {hasArtists ? <ArtistGrid artists={artists} /> : <ArtistSkeletons />}
+      </div>
+    </section>
+  );
+}
+
+interface ArtistGridProps {
+  artists: HomeArtistSummary[];
+}
+
+function ArtistGrid({ artists }: ArtistGridProps) {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      {artists.map((artist) => (
+        <Link
+          key={artist.id}
+          href={`/artists/${artist.id}`}
+          className="group flex flex-col gap-3 rounded-3xl border border-white/10 bg-white/5 p-5 transition hover:border-primary/40 hover:bg-white/10"
+        >
+          <div className="flex items-center gap-3">
+            <div className="relative h-14 w-14 overflow-hidden rounded-2xl border border-white/10 bg-neutral-900">
+              {artist.avatarUrl ? (
+                <Image src={artist.avatarUrl} alt={artist.name} fill className="object-cover" />
+              ) : (
+                <div className="flex h-full w-full items-center justify-center text-lg font-semibold text-white/70">
+                  {artist.name.slice(0, 2)}
+                </div>
+              )}
+            </div>
+            <div>
+              <p className="text-base font-semibold text-white group-hover:text-primary">{artist.name}</p>
+              <p className="text-xs uppercase tracking-[0.3em] text-white/50">
+                {t('artist.directory.projectCount', { count: artist.projectCount })}
+              </p>
+            </div>
+          </div>
+          <p className="flex-1 text-sm text-white/70 line-clamp-3">{artist.bio ?? t('artist.profile.emptyBioDetailed')}</p>
+          <div className="flex items-center justify-between text-xs text-white/60">
+            <span>{t('artist.directory.followerCount', { count: artist.followerCount })}</span>
+            <span className="rounded-full border border-white/10 px-3 py-1 text-white/70">
+              {t('artist.directory.viewProfile')}
+            </span>
+          </div>
+        </Link>
+      ))}
+    </>
+  );
+}
+
+function ArtistSkeletons() {
+  return (
+    <>
+      {Array.from({ length: 4 }).map((_, index) => (
+        <div key={`artist-skeleton-${index}`} className="h-56 animate-pulse rounded-3xl border border-white/10 bg-white/5" />
+      ))}
+    </>
+  );
+}

--- a/components/home/community-pulse-section.tsx
+++ b/components/home/community-pulse-section.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import Link from 'next/link';
+import { useTranslation } from 'react-i18next';
+
+import { SectionHeader } from '@/components/ui/headers/section-header';
+import type { CommunityPost } from '@/lib/data/community';
+
+interface CommunityPulseSectionProps {
+  featuredPost?: CommunityPost;
+  highlightedPosts: CommunityPost[];
+  hasPosts: boolean;
+}
+
+export function CommunityPulseSection({ featuredPost, highlightedPosts, hasPosts }: CommunityPulseSectionProps) {
+  const { t } = useTranslation();
+
+  return (
+    <section>
+      <SectionHeader
+        title={t('home.sections.communityPulse')}
+        href="/community"
+        ctaLabel={t('actions.viewMore') ?? undefined}
+      />
+      {hasPosts ? (
+        <CommunityFeed featuredPost={featuredPost} highlightedPosts={highlightedPosts} />
+      ) : (
+        <div className="mt-6 rounded-3xl border border-dashed border-white/10 bg-white/5 p-10 text-center text-sm text-white/60">
+          {t('home.empty.community')}
+        </div>
+      )}
+    </section>
+  );
+}
+
+interface CommunityFeedProps {
+  featuredPost?: CommunityPost;
+  highlightedPosts: CommunityPost[];
+}
+
+function CommunityFeed({ featuredPost, highlightedPosts }: CommunityFeedProps) {
+  const { t } = useTranslation();
+  const hasHighlights = highlightedPosts.length > 0;
+
+  return (
+    <div className="mt-6 grid gap-4 lg:grid-cols-[1.4fr_1fr] xl:grid-cols-[3fr_2fr]">
+      {featuredPost ? (
+        <Link
+          href={`/community/${featuredPost.id}`}
+          className="group flex h-full flex-col gap-6 rounded-3xl border border-white/10 bg-gradient-to-br from-white/10 via-white/5 to-white/[0.02] p-6 transition hover:border-primary/40 hover:from-primary/20 hover:via-primary/10 hover:to-primary/0"
+        >
+          <div className="flex flex-wrap items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.3em] text-white/60">
+            <span className="rounded-full bg-white/10 px-3 py-1 text-white">
+              {t(`community.filters.${featuredPost.category}`)}
+            </span>
+            {featuredPost.isTrending ? (
+              <span className="rounded-full bg-primary/20 px-3 py-1 text-primary">
+                {t('community.badges.trending')}
+              </span>
+            ) : null}
+          </div>
+          <div className="space-y-3">
+            <h3 className="text-2xl font-semibold text-white group-hover:text-primary">{featuredPost.title}</h3>
+            <p className="text-sm text-white/70 line-clamp-4">{featuredPost.content}</p>
+          </div>
+          <div className="flex flex-wrap items-center justify-between gap-3 text-xs text-white/60">
+            <span>{featuredPost.author?.name ?? t('community.defaultGuestName')}</span>
+            <div className="flex items-center gap-3">
+              <span>{t('community.likesLabel_other', { count: featuredPost.likes ?? 0 })}</span>
+              <span>{t('community.commentsLabel_other', { count: featuredPost.comments ?? 0 })}</span>
+            </div>
+          </div>
+        </Link>
+      ) : null}
+      <div className="flex flex-col gap-3 rounded-3xl border border-white/10 bg-white/5 p-5">
+        <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-[0.3em] text-white/50">
+          <span>{t('home.sections.communityPulse')}</span>
+          <Link href="/community" className="text-white/60 transition hover:text-white">
+            {t('actions.viewMore')}
+          </Link>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2">
+          {hasHighlights ? (
+            highlightedPosts.map((post) => (
+              <Link
+                key={post.id}
+                href={`/community/${post.id}`}
+                className="group flex flex-col gap-2 rounded-2xl border border-white/10 bg-neutral-950/60 px-4 py-3 transition hover:border-primary/40 hover:bg-neutral-900/80"
+              >
+                <div className="flex items-center justify-between text-[11px] uppercase tracking-[0.3em] text-white/50">
+                  <span className="truncate text-white/70">
+                    {t(`community.filters.${post.category}`)}
+                  </span>
+                  {post.isTrending ? (
+                    <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[10px] text-primary">
+                      {t('community.badges.trending')}
+                    </span>
+                  ) : null}
+                </div>
+                <p className="text-sm font-semibold text-white group-hover:text-primary line-clamp-2">{post.title}</p>
+                <p className="text-xs text-white/60 line-clamp-2">{post.content}</p>
+                <div className="mt-auto flex items-center justify-between text-[11px] text-white/50">
+                  <span className="truncate">{post.author?.name ?? t('community.defaultGuestName')}</span>
+                  <span>{t('community.likesLabel_other', { count: post.likes ?? 0 })}</span>
+                </div>
+              </Link>
+            ))
+          ) : (
+            <div className="col-span-full rounded-2xl border border-dashed border-white/10 bg-white/5 p-6 text-center text-xs text-white/50">
+              {t('home.empty.community')}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/home/hero-section.tsx
+++ b/components/home/hero-section.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import Link from 'next/link';
+import { Sparkles } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+interface HeroSectionProps {
+  projectsCount: number;
+  communityCount: number;
+  artistsCount: number;
+}
+
+export function HeroSection({ projectsCount, communityCount, artistsCount }: HeroSectionProps) {
+  const { t } = useTranslation();
+
+  return (
+    <section className="pt-6">
+      <div className="grid gap-8 rounded-4xl border border-white/10 bg-gradient-to-br from-neutral-900 via-neutral-950 to-neutral-950 p-10 lg:grid-cols-[3fr_2fr] lg:items-center">
+        <div className="space-y-6">
+          <span className="inline-flex items-center gap-2 rounded-full border border-white/20 px-4 py-1 text-xs font-semibold uppercase tracking-[0.4em] text-white/60">
+            <Sparkles className="h-4 w-4" />
+            {t('home.hero.tagline')}
+          </span>
+          <h1 className="text-4xl font-semibold leading-tight text-white md:text-5xl">
+            {t('home.hero.title')}
+          </h1>
+          <p className="max-w-2xl text-base text-white/70">{t('home.hero.subtitle')}</p>
+          <div className="flex flex-wrap gap-3">
+            <Link
+              href="/artists"
+              className="inline-flex items-center gap-2 rounded-full bg-primary px-5 py-2 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90"
+            >
+              {t('home.hero.ctaArtists')}
+            </Link>
+            <Link
+              href="/community"
+              className="inline-flex items-center gap-2 rounded-full border border-white/20 px-5 py-2 text-sm font-semibold text-white transition hover:border-white/40 hover:text-white"
+            >
+              {t('home.hero.ctaCommunity')}
+            </Link>
+          </div>
+        </div>
+        <div className="grid gap-4 rounded-3xl border border-white/10 bg-white/5 p-6 text-sm text-white/70">
+          <MetricRow label={t('home.hero.metrics.projects')} value={projectsCount} />
+          <MetricRow label={t('home.hero.metrics.community')} value={communityCount} />
+          <MetricRow label={t('home.hero.metrics.artists')} value={artistsCount} />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+interface MetricRowProps {
+  label: string;
+  value: number;
+}
+
+function MetricRow({ label, value }: MetricRowProps) {
+  return (
+    <div className="flex items-center justify-between">
+      <span>{label}</span>
+      <span className="text-2xl font-semibold text-white">{value}</span>
+    </div>
+  );
+}

--- a/components/home/project-spotlight-section.tsx
+++ b/components/home/project-spotlight-section.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import Link from 'next/link';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { ProjectCard } from '@/components/ui/cards/project-card';
+import { SectionHeader } from '@/components/ui/headers/section-header';
+import type { ProjectSummary } from '@/lib/api/projects';
+
+interface ProjectSpotlightSectionProps {
+  projects: ProjectSummary[];
+  isLoading: boolean;
+  isError: boolean;
+  onRetry: () => void;
+}
+
+export function ProjectSpotlightSection({ projects, isLoading, isError, onRetry }: ProjectSpotlightSectionProps) {
+  const { t } = useTranslation();
+  const popularProjects = useMemo(() => {
+    return [...projects].sort((a, b) => b.participants - a.participants).slice(0, 6);
+  }, [projects]);
+
+  return (
+    <section className="grid gap-6 lg:grid-cols-[2fr_1fr]">
+      <div className="space-y-6">
+        <SectionHeader
+          title={t('home.sections.spotlight')}
+          href="/projects"
+          ctaLabel={t('actions.viewMore') ?? undefined}
+        />
+        <ProjectContent
+          projects={popularProjects}
+          isLoading={isLoading}
+          isError={isError}
+          onRetry={onRetry}
+        />
+      </div>
+      <LiveAmaCard />
+    </section>
+  );
+}
+
+interface ProjectContentProps {
+  projects: ProjectSummary[];
+  isLoading: boolean;
+  isError: boolean;
+  onRetry: () => void;
+}
+
+function ProjectContent({ projects, isLoading, isError, onRetry }: ProjectContentProps) {
+  const { t } = useTranslation();
+
+  if (isLoading) {
+    return (
+      <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, index) => (
+          <ProjectSkeleton key={`project-skeleton-${index}`} className="animate-pulse" />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="rounded-3xl border border-red-500/30 bg-red-500/10 p-6 text-sm text-red-100">
+        <p>{t('home.errors.projects')}</p>
+        <button
+          type="button"
+          onClick={onRetry}
+          className="mt-4 inline-flex items-center rounded-full border border-red-400/40 px-4 py-2 text-xs font-semibold text-red-100 transition hover:border-red-300/60 hover:text-red-50"
+        >
+          {t('actions.viewMore')}
+        </button>
+      </div>
+    );
+  }
+
+  if (projects.length === 0) {
+    return (
+      <div className="rounded-3xl border border-white/10 bg-white/5 p-6 text-sm text-white/60">
+        {t('home.empty.projects')}
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+      {projects.map((project) => (
+        <ProjectCard key={project.id} project={project} />
+      ))}
+    </div>
+  );
+}
+
+interface ProjectSkeletonProps {
+  className?: string;
+}
+
+function ProjectSkeleton({ className = '' }: ProjectSkeletonProps) {
+  return (
+    <div className={`flex h-full flex-col overflow-hidden rounded-3xl border border-white/10 bg-white/5 ${className}`}>
+      <div className="h-52 w-full bg-white/10" />
+      <div className="flex flex-1 flex-col justify-between gap-4 p-5">
+        <div className="space-y-2">
+          <div className="h-3 w-1/3 rounded-full bg-white/10" />
+          <div className="h-5 w-3/4 rounded-full bg-white/20" />
+          <div className="h-3 w-1/2 rounded-full bg-white/10" />
+        </div>
+        <div className="space-y-2">
+          <div className="h-2 rounded-full bg-white/10" />
+          <div className="h-3 w-2/3 rounded-full bg-white/10" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function LiveAmaCard() {
+  const { t } = useTranslation();
+
+  return (
+    <div className="space-y-4 rounded-3xl border border-white/10 bg-white/5 p-6">
+      <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-white/60">
+        {t('home.liveAma.tag')}
+      </h3>
+      <p className="text-2xl font-semibold text-white">{t('home.liveAma.title')}</p>
+      <p className="text-sm text-white/60">{t('home.liveAma.description')}</p>
+      <Link
+        href="/projects/1"
+        className="inline-flex w-fit rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground"
+        aria-label={t('home.liveAma.ctaAria', { title: t('home.liveAma.title') })}
+      >
+        {t('home.liveAma.cta')}
+      </Link>
+    </div>
+  );
+}

--- a/components/home/resources-section.tsx
+++ b/components/home/resources-section.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { useTranslation } from 'react-i18next';
+
+import { CategoryFilter } from '@/components/ui/sections/category-filter';
+import { SectionHeader } from '@/components/ui/headers/section-header';
+
+export function ResourcesSection() {
+  const { t } = useTranslation();
+
+  return (
+    <section>
+      <SectionHeader
+        title={t('home.sections.resources')}
+        href="/partners"
+        ctaLabel={t('actions.viewMore') ?? undefined}
+      />
+      <CategoryFilter />
+    </section>
+  );
+}

--- a/components/home/store-section.tsx
+++ b/components/home/store-section.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useTranslation } from 'react-i18next';
+
+import type { StoreItem } from '@/app/api/store/route';
+import { StoreCard } from '@/components/ui/cards/store-card';
+import { SectionHeader } from '@/components/ui/headers/section-header';
+
+interface StoreSectionProps {
+  items: StoreItem[];
+  isLoading: boolean;
+}
+
+export function StoreSection({ items, isLoading }: StoreSectionProps) {
+  const { t } = useTranslation();
+
+  return (
+    <section>
+      <SectionHeader
+        title={t('home.store.title')}
+        href="/store"
+        ctaLabel={t('actions.viewMore') ?? undefined}
+      />
+      <StoreContent items={items} isLoading={isLoading} />
+    </section>
+  );
+}
+
+interface StoreContentProps {
+  items: StoreItem[];
+  isLoading: boolean;
+}
+
+function StoreContent({ items, isLoading }: StoreContentProps) {
+  const { t } = useTranslation();
+
+  if (isLoading) {
+    return (
+      <div className="grid gap-6 md:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, index) => (
+          <div key={`store-skeleton-${index}`} className="h-64 animate-pulse rounded-3xl bg-white/10" />
+        ))}
+      </div>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <div className="rounded-3xl border border-white/10 bg-white/5 p-6 text-sm text-white/60">
+        {t('home.empty.store')}
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-6 md:grid-cols-3">
+      {items.map((item) => (
+        <StoreCard key={item.id} product={item} />
+      ))}
+    </div>
+  );
+}

--- a/types/home.ts
+++ b/types/home.ts
@@ -1,0 +1,8 @@
+export interface HomeArtistSummary {
+  id: string;
+  name: string;
+  avatarUrl: string | null;
+  bio: string | null;
+  followerCount: number;
+  projectCount: number;
+}


### PR DESCRIPTION
## Summary
- extract the home page hero, spotlight, artist, community, resources, and store UI into dedicated client components for better modularity
- introduce a shared `HomeArtistSummary` type to reuse artist data across the page and new components
- simplify `app/page.tsx` to focus on data fetching and composing the new sections

## Testing
- npm run lint *(fails: existing unused variable violations in unrelated API/auth modules)*

------
https://chatgpt.com/codex/tasks/task_b_68e5cec65f388326bfc3d897969b3413