### PR TITLE
Fix community detail API lookup failure

### DIFF
--- a/app/api/community/[id]/route.ts
+++ b/app/api/community/[id]/route.ts
@@ -34,6 +34,8 @@ const isTrendingPost = (createdAt: Date, commentCount: number, likeCount: number
 
 const buildPostResponse = async (postId: string, viewerId?: string | null) => {
   try {
+    const db = await getDb();
+
     // 게시글과 작성자 정보를 함께 조회
     const postResult = await db
       .select({
@@ -62,7 +64,6 @@ const buildPostResponse = async (postId: string, viewerId?: string | null) => {
     }
 
     // 좋아요, 싫어요, 댓글 수를 별도로 조회
-    const db = await getDb();
     const [likesResult, dislikesResult, commentsResult] = await Promise.all([
       db.select({ count: count() }).from(postLikes).where(eq(postLikes.postId, postId)),
       db.select({ count: count() }).from(postDislikes).where(eq(postDislikes.postId, postId)),


### PR DESCRIPTION
## Summary
- initialize the database client before querying post details in the community detail API
- reuse the same client for subsequent count queries to avoid reference errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e60cb9747083269b6ea26d9278eaa5