### PR TITLE
Fix community post detail API DB initialization

### DIFF
--- a/app/api/community/[id]/route.ts
+++ b/app/api/community/[id]/route.ts
@@ -34,6 +34,8 @@ const isTrendingPost = (createdAt: Date, commentCount: number, likeCount: number
 
 const buildPostResponse = async (postId: string, viewerId?: string | null) => {
   try {
+    const db = await getDb();
+
     // 게시글과 작성자 정보를 함께 조회
     const postResult = await db
       .select({
@@ -62,7 +64,6 @@ const buildPostResponse = async (postId: string, viewerId?: string | null) => {
     }
 
     // 좋아요, 싫어요, 댓글 수를 별도로 조회
-    const db = await getDb();
     const [likesResult, dislikesResult, commentsResult] = await Promise.all([
       db.select({ count: count() }).from(postLikes).where(eq(postLikes.postId, postId)),
       db.select({ count: count() }).from(postDislikes).where(eq(postDislikes.postId, postId)),


### PR DESCRIPTION
## Summary
- initialize the database client before building the community post response
- reuse the same client when loading counts so the route no longer throws and returns 404

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68e60cb9747083269b6ea26d9278eaa5