### PR TITLE
fix: guard moderation admin endpoints when DB is unavailable

### DIFF
--- a/app/api/admin/moderation/route.ts
+++ b/app/api/admin/moderation/route.ts
@@ -1,7 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireApiUser } from '@/lib/auth/guards';
 import { UserRole } from '@/types/prisma';
-import { getReportedPostDetails, updateModerationStatus } from '@/lib/server/moderation';
+import {
+  ModerationDataUnavailableError,
+  getReportedPostDetails,
+  updateModerationStatus
+} from '@/lib/server/moderation';
 import { moderationStatusEnum } from '@/lib/db/schema';
 
 export async function GET(request: NextRequest) {
@@ -17,6 +21,13 @@ export async function GET(request: NextRequest) {
     const details = await getReportedPostDetails(postId);
     return NextResponse.json(details);
   } catch (error) {
+    if (error instanceof ModerationDataUnavailableError) {
+      return NextResponse.json(
+        { message: error.message },
+        { status: 503 }
+      );
+    }
+
     console.error('Failed to get reported post details:', error);
     return NextResponse.json(
       { message: 'Failed to get post details' },
@@ -55,6 +66,13 @@ export async function PATCH(request: NextRequest) {
 
     return NextResponse.json(updatedReport);
   } catch (error) {
+    if (error instanceof ModerationDataUnavailableError) {
+      return NextResponse.json(
+        { message: error.message },
+        { status: 503 }
+      );
+    }
+
     console.error('Failed to update moderation status:', error);
     return NextResponse.json(
       { message: 'Failed to update moderation status' },


### PR DESCRIPTION
## Summary
- add a reusable guard that skips moderation queries when the Drizzle client is disabled and expose a dedicated error
- respond with 503 from the admin moderation API when moderation data cannot be reached
- update the moderation service unit tests to cover the preview/disabled database scenario

## Testing
- npm run test -- __tests__/lib/server/moderation.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68e637abc7c083268fffc2bb2a56ca04